### PR TITLE
Draw polygons instead of line segments

### DIFF
--- a/lib/src/features/line_renderer.dart
+++ b/lib/src/features/line_renderer.dart
@@ -30,18 +30,18 @@ class LineRenderer extends FeatureRenderer {
       logger.log(() => 'rendering linestring');
       final path = Path();
       lines.forEach((line) {
-        line.asMap().forEach((index, point) {
+        final points = line.map((point) {
           if (point.length < 2) {
             throw Exception('invalid point ${point.length}');
           }
+
           final x = (point[0] / layer.extent) * tileSize;
           final y = (point[1] / layer.extent) * tileSize;
-          if (index == 0) {
-            path.moveTo(x, y);
-          } else {
-            path.lineTo(x, y);
-          }
-        });
+
+          return Offset(x, y);
+        }).toList(growable: false);
+
+        path.addPolygon(points, false);
       });
       if (!_isWithinClip(context, path)) {
         return;

--- a/lib/src/features/polygon_renderer.dart
+++ b/lib/src/features/polygon_renderer.dart
@@ -47,22 +47,20 @@ class PolygonRenderer extends FeatureRenderer {
       List<List<List<double>>> coordinates) {
     final path = Path();
     coordinates.forEach((ring) {
-      ring.asMap().forEach((index, point) {
+      final points = ring.map((point) {
         if (point.length < 2) {
           throw Exception('invalid point ${point.length}');
         }
+
         final x = (point[0] / layer.extent) * tileSize;
         final y = (point[1] / layer.extent) * tileSize;
-        if (index == 0) {
-          path.moveTo(x, y);
-        } else {
-          path.lineTo(x, y);
-        }
-        if (index == (ring.length - 1)) {
-          path.close();
-        }
-      });
+
+        return Offset(x, y);
+      }).toList(growable: false);
+
+      path.addPolygon(points, true);
     });
+
     if (!_isWithinClip(context, path)) {
       return;
     }

--- a/lib/src/features/symbol_line_renderer.dart
+++ b/lib/src/features/symbol_line_renderer.dart
@@ -37,19 +37,20 @@ class SymbolLineRenderer extends FeatureRenderer {
       if (text != null) {
         final path = Path();
         lines.forEach((line) {
-          line.asMap().forEach((index, point) {
+          final points = line.map((point) {
             if (point.length < 2) {
               throw Exception('invalid point ${point.length}');
             }
+
             final x = (point[0] / layer.extent) * tileSize;
             final y = (point[1] / layer.extent) * tileSize;
-            if (index == 0) {
-              path.moveTo(x, y);
-            } else {
-              path.lineTo(x, y);
-            }
-          });
+
+            return Offset(x, y);
+          }).toList(growable: false);
+
+          path.addPolygon(points, false);
         });
+
         final metrics = path.computeMetrics().toList();
         if (metrics.length > 0) {
           final abbreviated = TextAbbreviator().abbreviate(text);


### PR DESCRIPTION
Use `addPolygon()` instead of `lineTo()` to draw linestrings and polygons.

Has better performance for large number of points and simplifies code.

https://github.com/greensopinion/flutter-vector-map-tiles/issues/10#issuecomment-997445131