### PR TITLE
record timeline events for profiling

### DIFF
--- a/lib/src/image_renderer.dart
+++ b/lib/src/image_renderer.dart
@@ -1,4 +1,7 @@
+import 'dart:developer';
 import 'dart:ui';
+
+import 'package:vector_tile_renderer/src/profiling.dart';
 
 import 'constants.dart';
 import 'logger.dart';
@@ -28,14 +31,21 @@ class ImageRenderer {
   /// [tileset] the tileset, having vector tiles by `'source'` ID as defined by the theme
   Future<Image> render(Tileset tileset,
       {double zoomScaleFactor = 1.0, required double zoom}) {
-    final recorder = PictureRecorder();
-    double size = scale * tileSize;
-    final rect = Rect.fromLTRB(0, 0, size, size);
-    final canvas = Canvas(recorder, rect);
-    canvas.clipRect(rect);
-    canvas.scale(scale.toDouble(), scale.toDouble());
-    Renderer(theme: theme, logger: logger)
-        .render(canvas, tileset, zoomScaleFactor: zoomScaleFactor, zoom: zoom);
-    return recorder.endRecording().toImage(size.floor(), size.floor());
+    final task = TimelineTask(filterKey: timelineTaskFilterKey)
+      ..start('RenderImage');
+
+    try {
+      final recorder = PictureRecorder();
+      double size = scale * tileSize;
+      final rect = Rect.fromLTRB(0, 0, size, size);
+      final canvas = Canvas(recorder, rect);
+      canvas.clipRect(rect);
+      canvas.scale(scale.toDouble(), scale.toDouble());
+      Renderer(theme: theme, logger: logger).render(canvas, tileset,
+          zoomScaleFactor: zoomScaleFactor, zoom: zoom);
+      return recorder.endRecording().toImage(size.floor(), size.floor());
+    } finally {
+      task.finish();
+    }
   }
 }

--- a/lib/src/image_to_png.dart
+++ b/lib/src/image_to_png.dart
@@ -7,6 +7,6 @@ extension ImageToPng on Image {
     if (bytes == null) {
       throw Exception('Cannot encode as png');
     }
-    return bytes.buffer.asUint8List(bytes.offsetInBytes, bytes.lengthInBytes);
+    return Uint8List.sublistView(bytes);
   }
 }

--- a/lib/src/profiling.dart
+++ b/lib/src/profiling.dart
@@ -1,0 +1,13 @@
+import 'dart:developer';
+
+/// Filter key for [TimelineTask]s that this library records.
+///
+/// Asynchronous tasks that are recorded by this library will be displayed in
+/// their own lane, with this value as its name.
+const timelineTaskFilterKey = 'VectorTileRenderer';
+
+/// Prefix for [Timeline] events that this library records.
+///
+/// By searching for this value in the DevTools Performance page, you can find
+/// all the [Timeline] events recorded by this library.
+const timelinePrefix = 'VTR';

--- a/lib/src/renderer.dart
+++ b/lib/src/renderer.dart
@@ -1,9 +1,11 @@
+import 'dart:developer';
 import 'dart:ui';
 
 import 'constants.dart';
 import 'context.dart';
 import 'features/feature_renderer.dart';
 import 'logger.dart';
+import 'profiling.dart';
 import 'themes/theme.dart';
 import 'tileset.dart';
 
@@ -29,18 +31,20 @@ class Renderer {
   ///        so that a portion of a tile can be rendered to a canvas
   void render(Canvas canvas, Tileset tileset,
       {Rect? clip, required double zoomScaleFactor, required double zoom}) {
-    final tileSpace =
-        Rect.fromLTWH(0, 0, tileSize.toDouble(), tileSize.toDouble());
-    canvas.save();
-    canvas.clipRect(tileSpace);
-    final tileClip = clip ?? tileSpace;
-    final context = Context(logger, canvas, featureRenderer, tileset,
-        zoomScaleFactor, zoom, tileSpace, tileClip);
-    final effectiveTheme = theme.atZoom(zoom);
-    effectiveTheme.layers.forEach((themeLayer) {
-      logger.log(() => 'rendering theme layer ${themeLayer.id}');
-      themeLayer.render(context);
+    Timeline.timeSync('$timelinePrefix::Render', () {
+      final tileSpace =
+          Rect.fromLTWH(0, 0, tileSize.toDouble(), tileSize.toDouble());
+      canvas.save();
+      canvas.clipRect(tileSpace);
+      final tileClip = clip ?? tileSpace;
+      final context = Context(logger, canvas, featureRenderer, tileset,
+          zoomScaleFactor, zoom, tileSpace, tileClip);
+      final effectiveTheme = theme.atZoom(zoom);
+      effectiveTheme.layers.forEach((themeLayer) {
+        logger.log(() => 'rendering theme layer ${themeLayer.id}');
+        themeLayer.render(context);
+      });
+      canvas.restore();
     });
-    canvas.restore();
   }
 }

--- a/lib/src/themes/theme_reader.dart
+++ b/lib/src/themes/theme_reader.dart
@@ -1,8 +1,10 @@
 import 'dart:core';
+import 'dart:developer';
 
 import 'package:flutter/painting.dart';
 
 import '../logger.dart';
+import '../profiling.dart';
 import 'color_parser.dart';
 import 'expression/expression.dart';
 import 'expression/literal_expression.dart';
@@ -18,6 +20,7 @@ class ThemeReader {
   late final SelectorFactory selectorFactory;
   late final PaintFactory paintFactory;
   late final ExpressionParser expressionParser;
+
   ThemeReader({Logger? logger}) : this.logger = logger ?? Logger.noop() {
     selectorFactory = SelectorFactory(this.logger);
     paintFactory = PaintFactory(this.logger);
@@ -25,14 +28,16 @@ class ThemeReader {
   }
 
   Theme read(Map<String, dynamic> json) {
-    final id = json['id'] ?? 'default';
-    final version = json['metadata']?['version']?.toString() ?? 'none';
-    final layers = json['layers'] as List<dynamic>;
-    final themeLayers = layers
-        .map((layer) => _toThemeLayer(layer))
-        .whereType<ThemeLayer>()
-        .toList();
-    return Theme(id: id, version: version, layers: themeLayers);
+    return Timeline.timeSync('$timelinePrefix::ReadTheme', () {
+      final id = json['id'] ?? 'default';
+      final version = json['metadata']?['version']?.toString() ?? 'none';
+      final layers = json['layers'] as List<dynamic>;
+      final themeLayers = layers
+          .map((layer) => _toThemeLayer(layer))
+          .whereType<ThemeLayer>()
+          .toList();
+      return Theme(id: id, version: version, layers: themeLayers);
+    });
   }
 
   ThemeLayer? _toThemeLayer(jsonLayer) {

--- a/lib/src/tileset.dart
+++ b/lib/src/tileset.dart
@@ -1,5 +1,8 @@
+import 'dart:developer';
+
 import 'package:vector_tile/vector_tile.dart';
 
+import 'profiling.dart';
 import 'themes/feature_resolver.dart';
 import 'themes/theme.dart';
 import 'themes/theme_layers.dart';
@@ -39,17 +42,19 @@ class TilesetPreprocessor {
   ///
   /// Returns a pre-processed tileset.
   Tileset preprocess(Tileset tileset) {
-    final featureResolver = tileset.resolver is CachingLayerFeatureResolver
-        ? tileset.resolver
-        : CachingLayerFeatureResolver(tileset.resolver);
+    return Timeline.timeSync('$timelinePrefix::PreprocessTileset', () {
+      final featureResolver = tileset.resolver is CachingLayerFeatureResolver
+          ? tileset.resolver
+          : CachingLayerFeatureResolver(tileset.resolver);
 
-    for (final themeLayer in theme.layers.whereType<DefaultLayer>()) {
-      for (final feature
-          in featureResolver.resolveFeatures(themeLayer.selector)) {
-        feature.feature.decodeGeometry();
+      for (final themeLayer in theme.layers.whereType<DefaultLayer>()) {
+        for (final feature
+            in featureResolver.resolveFeatures(themeLayer.selector)) {
+          feature.feature.decodeGeometry();
+        }
       }
-    }
 
-    return Tileset._preprocessed(tileset, featureResolver);
+      return Tileset._preprocessed(tileset, featureResolver);
+    });
   }
 }

--- a/lib/src/vector_tile_reader.dart
+++ b/lib/src/vector_tile_reader.dart
@@ -1,9 +1,14 @@
+import 'dart:developer';
 import 'dart:typed_data';
 
 import 'package:vector_tile/vector_tile.dart';
 
+import 'profiling.dart';
+
 class VectorTileReader {
   VectorTile read(Uint8List bytes) {
-    return VectorTile.fromBytes(bytes: bytes);
+    return Timeline.timeSync('$timelinePrefix::ReadTile', () {
+      return VectorTile.fromBytes(bytes: bytes);
+    });
   }
 }


### PR DESCRIPTION
With this change, key tasks will be recorded to the timeline for performance profiling.

Synchronous tasks:

- `VTR::ReadTheme`
- `VTR::ReadTile`
- `VTR::PreprocessTileset`
- `VTR::Render`

Asynchronous tasks:

- `RenderImage`