### PR TITLE
use simpler `VectorTileValue` API

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -169,7 +169,7 @@ packages:
       name: vector_tile
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
+    version: "0.3.1"
   vector_tile_renderer:
     dependency: "direct main"
     description:

--- a/lib/src/themes/expression/expression.dart
+++ b/lib/src/themes/expression/expression.dart
@@ -1,4 +1,5 @@
 import 'package:vector_tile/vector_tile.dart';
+import 'package:fixnum/fixnum.dart';
 
 import '../../logger.dart';
 
@@ -21,13 +22,11 @@ class EvaluationContext {
       return zoom;
     }
     final properties = _properties();
-    final value = properties[name];
-    if (value != null) {
-      return value.dartStringValue ??
-          value.dartIntValue?.toInt() ??
-          value.dartDoubleValue ??
-          value.dartBoolValue;
+    final value = properties[name]?.value;
+    if (value is Int64) {
+      return value.toInt();
     }
+    return value;
   }
 
   _typeName() {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -353,7 +353,7 @@ packages:
       name: vector_tile
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
+    version: "0.3.1"
   vm_service:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  vector_tile: ^0.3.0
+  vector_tile: ^0.3.1
 
 dev_dependencies:
   benchmark_harness: ^2.0.0


### PR DESCRIPTION
The updated `VectorTileValue` API is more storage efficient and cheaper to access. This change makes use of it.