### PR TITLE
bug fix to theme filters that reference zoom level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.4.0
+
+* bug fix to theme filters that reference zoom level
+* breaking API change, `TilesetPreprocessor` now requires a zoom level
 ## 2.3.3
 
 * improve support for color expressions

--- a/example/lib/tile.dart
+++ b/example/lib/tile.dart
@@ -100,8 +100,8 @@ class _TileState extends State<Tile> {
         .asUint8List(tileData.offsetInBytes, tileData.lengthInBytes);
     final tile = TileFactory(theme, Logger.noop())
         .create(VectorTileReader().read(tileBytes));
-    final tileset =
-        TilesetPreprocessor(theme).preprocess(Tileset({'openmaptiles': tile}));
+    final tileset = TilesetPreprocessor(theme)
+        .preprocess(Tileset({'openmaptiles': tile}), zoom: 14);
     setState(() {
       this.tileset = tileset;
     });

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -183,7 +183,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.3.3"
+    version: "2.4.0"
 sdks:
   dart: ">=2.14.0 <3.0.0"
   flutter: ">=1.17.0"

--- a/lib/src/themes/feature_resolver.dart
+++ b/lib/src/themes/feature_resolver.dart
@@ -6,7 +6,7 @@ import 'selector.dart';
 /// [TileLayerSelector].
 abstract class LayerFeatureResolver {
   /// Provides the features resolved using the given [selector].
-  Iterable<LayerFeature> resolveFeatures(TileLayerSelector selector);
+  Iterable<LayerFeature> resolveFeatures(TileLayerSelector selector, int zoom);
 }
 
 /// Default implementation of [LayerFeatureResolver] that resolves
@@ -17,9 +17,11 @@ class DefaultLayerFeatureResolver implements LayerFeatureResolver {
   final Tileset _tileset;
 
   @override
-  Iterable<LayerFeature> resolveFeatures(TileLayerSelector selector) sync* {
-    for (final layer in selector.select(_tileset)) {
-      for (final feature in selector.layerSelector.features(layer.features)) {
+  Iterable<LayerFeature> resolveFeatures(
+      TileLayerSelector selector, int zoom) sync* {
+    for (final layer in selector.select(_tileset, zoom)) {
+      for (final feature
+          in selector.layerSelector.features(layer.features, zoom)) {
         yield LayerFeature(layer, feature);
       }
     }
@@ -35,10 +37,10 @@ class CachingLayerFeatureResolver implements LayerFeatureResolver {
   final _cache = <String, List<LayerFeature>>{};
 
   @override
-  Iterable<LayerFeature> resolveFeatures(TileLayerSelector selector) {
+  Iterable<LayerFeature> resolveFeatures(TileLayerSelector selector, int zoom) {
     return _cache.putIfAbsent(
-      selector.cacheKey,
-      () => _delegate.resolveFeatures(selector).toList(growable: false),
+      "$zoom:${selector.cacheKey}",
+      () => _delegate.resolveFeatures(selector, zoom).toList(growable: false),
     );
   }
 }

--- a/lib/src/themes/theme_layers.dart
+++ b/lib/src/themes/theme_layers.dart
@@ -27,7 +27,9 @@ class DefaultLayer extends ThemeLayer {
 
   @override
   void render(Context context) {
-    final layers = selector.select(context.tileset).toList(growable: false);
+    final layers = selector
+        .select(context.tileset, context.zoom.truncate())
+        .toList(growable: false);
     assert(layers.length <= 1);
 
     if (layers.isEmpty) {
@@ -35,7 +37,7 @@ class DefaultLayer extends ThemeLayer {
     }
 
     final features = context.tileset.resolver
-        .resolveFeatures(this.selector)
+        .resolveFeatures(this.selector, context.zoom.truncate())
         .toList(growable: false);
 
     if (features.isEmpty) {

--- a/lib/src/tileset.dart
+++ b/lib/src/tileset.dart
@@ -37,15 +37,19 @@ class TilesetPreprocessor {
   /// Pre-processes a tileset to eliminate some expensive processing from
   /// the rendering stage.
   ///
+  /// [zoom] the zoom level at which the tileset should be preprocessed. The
+  ///        zoom level may be referenced by expressions in the theme, for example
+  ///        as a layer filter.
+  ///
   /// Returns a pre-processed tileset.
-  Tileset preprocess(Tileset tileset) {
+  Tileset preprocess(Tileset tileset, {required double zoom}) {
     return profileSync('PreprocessTileset', () {
       final featureResolver = tileset.resolver is CachingLayerFeatureResolver
           ? tileset.resolver
           : CachingLayerFeatureResolver(tileset.resolver);
 
       for (final themeLayer in theme.layers.whereType<DefaultLayer>()) {
-        featureResolver.resolveFeatures(themeLayer.selector);
+        featureResolver.resolveFeatures(themeLayer.selector, zoom.truncate());
       }
       return Tileset._preprocessed(tileset, featureResolver);
     });

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: vector_tile_renderer
 description: A vector tile renderer for use in creating map tile images or writing to a canvas.
-version: 2.3.3
+version: 2.4.0
 homepage: https://github.com/greensopinion/dart-vector-tile-renderer
 
 environment:

--- a/test/benchmark/rendering_test.dart
+++ b/test/benchmark/rendering_test.dart
@@ -60,7 +60,7 @@ class RenderPicture extends BenchmarkBase {
     final tileset = Tileset({'openmaptiles': testTile});
 
     this.tileset = preprocessTile
-        ? TilesetPreprocessor(theme).preprocess(tileset)
+        ? TilesetPreprocessor(theme).preprocess(tileset, zoom: 1)
         : tileset;
   }
 

--- a/test/src/themes/selector_factory_test.dart
+++ b/test/src/themes/selector_factory_test.dart
@@ -11,10 +11,11 @@ void main() {
         await readTestTile(ProvidedThemes.lightTheme(logger: testLogger));
     final transportationLayer =
         tile.layers.where((layer) => layer.name == 'transportation').first;
-    expect(selector.layerSelector.select(tile.layers).toList(),
+    expect(selector.layerSelector.select(tile.layers, 1).toList(),
         contains(transportationLayer));
-    final selectedFeatures =
-        selector.layerSelector.features(transportationLayer.features).toList();
+    final selectedFeatures = selector.layerSelector
+        .features(transportationLayer.features, 1)
+        .toList();
     expect(selectedFeatures, isNotEmpty);
     expect(selectedFeatures.length, 206);
   });


### PR DESCRIPTION
Pass a zoom level when selecting layers and
    applying layer filters from a theme. This
    fixes a bug where filters that referenced
    the zoom level would always evaluate to
    a zoom level of 1. For specific filters,
    this bug resulted in theme elements not
    being rendered because the filter would
    evaluate to false. By passing the zoom
    level in when preprocessing or rendering
    filters are applied correctly.