### PR TITLE
add line type support for polygon source layers

### DIFF
--- a/lib/src/features/feature_renderer.dart
+++ b/lib/src/features/feature_renderer.dart
@@ -4,9 +4,10 @@ import '../model/tile_model.dart';
 import '../themes/style.dart';
 import '../themes/theme.dart';
 import 'line_renderer.dart';
-import 'polygon_renderer.dart';
+import 'fill_renderer.dart';
 import 'symbol_line_renderer.dart';
 import 'symbol_point_renderer.dart';
+import 'symbol_polygon_renderer.dart';
 
 abstract class FeatureRenderer {
   void render(
@@ -20,7 +21,7 @@ abstract class FeatureRenderer {
 
 class FeatureDispatcher extends FeatureRenderer {
   final Logger logger;
-  final Map<TileFeatureType, FeatureRenderer> typeToRenderer;
+  final Map<ThemeLayerType, FeatureRenderer> typeToRenderer;
   final Map<TileFeatureType, FeatureRenderer> symbolTypeToRenderer;
 
   FeatureDispatcher(this.logger)
@@ -34,10 +35,13 @@ class FeatureDispatcher extends FeatureRenderer {
     TileLayer layer,
     TileFeature feature,
   ) {
-    final rendererMapping = layerType == ThemeLayerType.symbol
-        ? symbolTypeToRenderer
-        : typeToRenderer;
-    final delegate = rendererMapping[feature.type];
+    FeatureRenderer? delegate;
+    if (layerType == ThemeLayerType.symbol) {
+      delegate = symbolTypeToRenderer[feature.type];
+    } else {
+      delegate = typeToRenderer[layerType];
+    }
+
     if (delegate == null) {
       logger.warn(() =>
           'layer type $layerType feature ${feature.type} is not implemented');
@@ -46,11 +50,11 @@ class FeatureDispatcher extends FeatureRenderer {
     }
   }
 
-  static Map<TileFeatureType, FeatureRenderer> createDispatchMapping(
+  static Map<ThemeLayerType, FeatureRenderer> createDispatchMapping(
       Logger logger) {
     return {
-      TileFeatureType.polygon: PolygonRenderer(logger),
-      TileFeatureType.linestring: LineRenderer(logger),
+      ThemeLayerType.fill: FillRenderer(logger),
+      ThemeLayerType.line: LineRenderer(logger),
     };
   }
 
@@ -58,7 +62,7 @@ class FeatureDispatcher extends FeatureRenderer {
       Logger logger) {
     return {
       TileFeatureType.point: SymbolPointRenderer(logger),
-      TileFeatureType.linestring: SymbolLineRenderer(logger)
+      TileFeatureType.linestring: SymbolLineRenderer(logger),
     };
   }
 }

--- a/lib/src/features/feature_renderer.dart
+++ b/lib/src/features/feature_renderer.dart
@@ -7,7 +7,6 @@ import 'line_renderer.dart';
 import 'fill_renderer.dart';
 import 'symbol_line_renderer.dart';
 import 'symbol_point_renderer.dart';
-import 'symbol_polygon_renderer.dart';
 
 abstract class FeatureRenderer {
   void render(
@@ -54,6 +53,7 @@ class FeatureDispatcher extends FeatureRenderer {
       Logger logger) {
     return {
       ThemeLayerType.fill: FillRenderer(logger),
+      ThemeLayerType.fill_extrusion: FillRenderer(logger),
       ThemeLayerType.line: LineRenderer(logger),
     };
   }

--- a/lib/src/features/fill_renderer.dart
+++ b/lib/src/features/fill_renderer.dart
@@ -4,9 +4,9 @@ import '../themes/expression/expression.dart';
 import '../themes/style.dart';
 import 'feature_renderer.dart';
 
-class PolygonRenderer extends FeatureRenderer {
+class FillRenderer extends FeatureRenderer {
   final Logger logger;
-  PolygonRenderer(this.logger);
+  FillRenderer(this.logger);
 
   @override
   void render(


### PR DESCRIPTION
Let me open this PR with a thank you for this library, it has been a life saver for me and other's working on a map project that we had run into performance issues with native rendering in flutter_map.

For my current implementation of vector tiles I have multiple polygon source layers which we want to apply border styling to; which unfortunately the options provided by the style spec don't allow us to have the control we would like without having to resort to using a line type or cloning our polygons into a line layer when we are making the vector tiles.

The ability has been added for the line type to be applied to Polygons (and Multi-Polygons). It uses the existing line styler to apply the styles and then just using the existing line painter to paint the lines.

I am more than happy to make changes on my end for code styling, performance tuning, tests, etc if required.

I am also looking at adding a `symbol_polygon_renderer` in the near future due to the geojson feature types we are working with that required this PR.