### PR TITLE
fix zig-zag decoding

### DIFF
--- a/lib/src/model/geometry_decoding.dart
+++ b/lib/src/model/geometry_decoding.dart
@@ -24,7 +24,7 @@ _Command _decodeCommand(int command) {
 int _decodeCommandLength(int command) => command >> 3;
 
 @pragma('vm:prefer-inline')
-int _decodeZigZag(int value) => (value >> 1) ^ -(value & 1);
+int _decodeZigZag(int value) => ((value >> 1) ^ -(value & 1)).toSigned(32);
 
 Iterable<TilePoint> decodePoints(List<int> geometry) sync* {
   final it = geometry.iterator;

--- a/test/src/model/geometry_decoding_test.dart
+++ b/test/src/model/geometry_decoding_test.dart
@@ -12,7 +12,7 @@ const closePath = 0x7;
 
 int command(int command, int length) => length << 3 | command;
 
-int zigZag(int n) => (n << 1) ^ (n >> 31);
+int zigZag(int n) => ((n << 1) ^ (n >> 31)).toSigned(32);
 
 void main() {
   final uiGeometry = UiGeometry();


### PR DESCRIPTION
To make bitwise operations platform independent the
[docs](https://dart.dev/guides/language/numbers#what-should-you-do)
recommend coercing to signed 32 bit integers.

Fixes #7