### PR TITLE
refactor to an `Expando` instead of extending `Paint`

### DIFF
--- a/lib/src/features/line_renderer.dart
+++ b/lib/src/features/line_renderer.dart
@@ -3,6 +3,7 @@ import '../context.dart';
 import '../path/path_transform.dart';
 import '../path/ring_number_provider.dart';
 import '../themes/expression/expression.dart';
+import '../themes/paint_factory.dart';
 import '../themes/style.dart';
 import 'feature_renderer.dart';
 import 'line_styler.dart';

--- a/lib/src/themes/paint_factory.dart
+++ b/lib/src/themes/paint_factory.dart
@@ -6,14 +6,14 @@ import 'expression/expression.dart';
 import 'expression/literal_expression.dart';
 import 'expression/numeric_expression.dart';
 
-class PaintExpression extends Expression<PaintModel> {
+class PaintExpression extends Expression<Paint> {
   final PaintStyle _delegate;
 
   PaintExpression(this._delegate)
       : super(_cacheKey(_delegate), _properties(_delegate));
 
   @override
-  PaintModel? evaluate(EvaluationContext context) => _delegate.paint(context);
+  Paint? evaluate(EvaluationContext context) => _delegate.paint(context);
 
   @override
   bool get isConstant => false;
@@ -28,8 +28,12 @@ class PaintExpression extends Expression<PaintModel> {
       };
 }
 
-class PaintModel extends Paint {
-  List<double>? strokeDashPattern;
+final _paintStrokeDashExpando = Expando<List<double>>();
+
+extension PaintExtension on Paint {
+  List<double>? get strokeDashPattern => _paintStrokeDashExpando[this];
+  set strokeDashPattern(List<double>? value) =>
+      _paintStrokeDashExpando[this] = value;
 }
 
 class PaintStyle {
@@ -48,7 +52,7 @@ class PaintStyle {
       required this.color,
       required this.strokeDashPattern});
 
-  PaintModel? paint(EvaluationContext context) {
+  Paint? paint(EvaluationContext context) {
     final opacity = this.opacity.evaluate(context);
     if (opacity != null && opacity <= 0) {
       return null;
@@ -57,7 +61,7 @@ class PaintStyle {
     if (color == null) {
       return null;
     }
-    final paint = PaintModel()
+    final paint = Paint()
       ..style = paintingStyle
       ..strokeDashPattern = strokeDashPattern;
     if (opacity != null && opacity < 1.0) {
@@ -81,7 +85,7 @@ class PaintFactory {
   final ExpressionParser expressionParser;
   PaintFactory(this.logger) : expressionParser = ExpressionParser(logger);
 
-  Expression<PaintModel>? create(
+  Expression<Paint>? create(
       String id, PaintingStyle style, String prefix, paint,
       {double? defaultStrokeWidth = 1.0}) {
     if (paint == null) {

--- a/lib/src/themes/style.dart
+++ b/lib/src/themes/style.dart
@@ -4,23 +4,22 @@ import 'dart:math';
 import 'dart:ui';
 
 import 'package:flutter/widgets.dart';
-import 'package:vector_tile_renderer/src/themes/paint_factory.dart';
-import 'expression/expression.dart';
 
 import '../extensions.dart';
+import 'expression/expression.dart';
 
 typedef ColorZoomFunction = Color? Function(double zoom);
 typedef TextTransformFunction = String? Function(String? text);
 
 class Style {
-  final Expression<PaintModel>? fillPaint;
+  final Expression<Paint>? fillPaint;
   final Extrusion? fillExtrusion;
-  final Expression<PaintModel>? linePaint;
+  final Expression<Paint>? linePaint;
   final LineLayout? lineLayout;
-  final Expression<PaintModel>? textPaint;
+  final Expression<Paint>? textPaint;
   final TextLayout? textLayout;
   final Expression<List<Shadow>>? textHalo;
-  final Expression<PaintModel>? outlinePaint;
+  final Expression<Paint>? outlinePaint;
 
   Style(
       {this.fillPaint,


### PR DESCRIPTION
Extending `Paint` makes it impossible to compile for Web.

It's not documented, but extending classes from `dart:ui` should be
avoided because implementations are often platform-dependent.