### PR TITLE
prevent exception on maxZoom too high

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.5.7
+
+* bug fix for themes that specify maxZoom > 25
 ## 2.5.6
 
 * performance improvement when rendering a tile at different zoom levels

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -176,7 +176,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.5.6"
+    version: "2.5.7"
 sdks:
   dart: ">=2.17.0 <3.0.0"
   flutter: ">=1.17.0"

--- a/lib/src/themes/feature_resolver.dart
+++ b/lib/src/themes/feature_resolver.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import '../model/tile_model.dart';
 import '../tileset.dart';
 import 'selector.dart';
@@ -59,10 +61,11 @@ class CachingLayerFeatureResolver implements LayerFeatureResolver {
   }
 
   Map<String, List<LayerFeature>> _cache(int zoom) {
-    var cache = _cacheByZoom[zoom];
+    final index = min(zoom, _maximumConceivableZoom);
+    var cache = _cacheByZoom[index];
     if (cache == null) {
       cache = {};
-      _cacheByZoom[zoom] = cache;
+      _cacheByZoom[index] = cache;
     }
     return cache;
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: vector_tile_renderer
 description: A vector tile renderer for use in creating map tile images or writing to a canvas.
-version: 2.5.6
+version: 2.5.7
 homepage: https://github.com/greensopinion/dart-vector-tile-renderer
 
 environment:


### PR DESCRIPTION
themes that specify maxzoom > 25 or
maps zoomed to level > 25 could result
in an exception. Fix this by bounding
cache to array size.

I've seen this happen in the field: in rare cases with `flutter_map` a zoom level of 100 is used. I haven't determined the root cause, but this will address the symptom.