### PR TITLE
avoid exporting unnecessary symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.0
+
+* improve exports to avoid naming conflicts
 ## 2.6.3
 
 * fix performance regression on Flutter 3.3.1 when running in debug mode

--- a/lib/src/vector_tile_extensions.dart
+++ b/lib/src/vector_tile_extensions.dart
@@ -1,4 +1,4 @@
-import '../vector_tile_renderer.dart';
+import 'package:vector_tile/vector_tile.dart';
 
 extension VectorTileFeatureExtension on VectorTileFeature {
   String? stringProperty(String name) {

--- a/lib/vector_tile_renderer.dart
+++ b/lib/vector_tile_renderer.dart
@@ -1,6 +1,6 @@
 library vector_tile_renderer;
 
-export 'package:vector_tile/vector_tile.dart';
+export 'package:vector_tile/vector_tile.dart' show VectorTile;
 
 export 'src/image_renderer.dart';
 export 'src/image_to_png.dart';

--- a/test/src/fakes.dart
+++ b/test/src/fakes.dart
@@ -1,5 +1,5 @@
 import 'package:test/fake.dart';
-import 'package:vector_tile_renderer/vector_tile_renderer.dart';
+import 'package:vector_tile/vector_tile.dart';
 
 class FakeVectorTileLayer extends Fake implements VectorTileLayer {
   final String _name;

--- a/test/src/vector_tile_reader_test.dart
+++ b/test/src/vector_tile_reader_test.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:test/test.dart';
 import 'package:vector_tile_renderer/vector_tile_renderer.dart';
+import 'package:vector_tile/vector_tile.dart';
 import 'extensions.dart';
 
 void main() {


### PR DESCRIPTION
Avoid exporting VectorTileLayer so that it
doesnt occupy the namespace.