### PR TITLE
Support is-supported-script expression

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -169,7 +169,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "3.0.4"
+    version: "3.1.0"
 sdks:
   dart: ">=2.17.0 <3.0.0"
   flutter: ">=2.14.0"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -5,58 +5,66 @@ packages:
     dependency: transitive
     description:
       name: async
-      url: "https://pub.dartlang.org"
+      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      url: "https://pub.dev"
     source: hosted
-    version: "2.9.0"
+    version: "2.10.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      url: "https://pub.dartlang.org"
+      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   characters:
     dependency: transitive
     description:
       name: characters
-      url: "https://pub.dartlang.org"
+      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
   clock:
     dependency: transitive
     description:
       name: clock
-      url: "https://pub.dartlang.org"
+      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.dartlang.org"
+      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   cupertino_icons:
     dependency: "direct main"
     description:
       name: cupertino_icons
-      url: "https://pub.dartlang.org"
+      sha256: e35129dc44c9118cee2a5603506d823bab99c68393879edb440e0090d07586be
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.3"
+    version: "1.0.5"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
-      url: "https://pub.dartlang.org"
+      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
   fixnum:
     dependency: transitive
     description:
       name: fixnum
-      url: "https://pub.dartlang.org"
+      sha256: "04be3e934c52e082558cc9ee21f42f5c1cd7a1262f4c63cd0357c08d5bba81ec"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.1"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -67,41 +75,54 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.5"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      url: "https://pub.dartlang.org"
+      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.12.12"
+    version: "0.12.13"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      url: "https://pub.dartlang.org"
+      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      url: "https://pub.dev"
     source: hosted
-    version: "0.1.5"
+    version: "0.2.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      url: "https://pub.dev"
     source: hosted
     version: "1.8.0"
   path:
     dependency: transitive
     description:
       name: path
-      url: "https://pub.dartlang.org"
+      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
+      url: "https://pub.dev"
     source: hosted
     version: "1.8.2"
   protobuf:
     dependency: transitive
     description:
       name: protobuf
-      url: "https://pub.dartlang.org"
+      sha256: "01dd9bd0fa02548bf2ceee13545d4a0ec6046459d847b6b061d8a27237108a08"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -111,56 +132,64 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      url: "https://pub.dartlang.org"
+      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      url: "https://pub.dartlang.org"
+      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      url: "https://pub.dartlang.org"
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.2.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      url: "https://pub.dartlang.org"
+      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      url: "https://pub.dartlang.org"
+      sha256: ad540f65f92caa91bf21dfc8ffb8c589d6e4dc0c2267818b4cc2792857706206
+      url: "https://pub.dev"
     source: hosted
-    version: "0.4.12"
+    version: "0.4.16"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      url: "https://pub.dartlang.org"
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
   vector_tile:
     dependency: transitive
     description:
       name: vector_tile
-      url: "https://pub.dartlang.org"
+      sha256: "2ac77f6bbd7ddd97efe059207d67bb7eaf807ab98ad58d99fe41a22c230f44e1"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
   vector_tile_renderer:
@@ -171,5 +200,5 @@ packages:
     source: path
     version: "3.1.0"
 sdks:
-  dart: ">=2.17.0 <3.0.0"
+  dart: ">=2.18.0 <4.0.0"
   flutter: ">=2.14.0"

--- a/lib/src/themes/expression/is_supported_script_expression.dart
+++ b/lib/src/themes/expression/is_supported_script_expression.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/widgets.dart';
+
+import 'expression.dart';
+
+class IsSupportedScriptExpression extends Expression {
+  final Expression _expression;
+
+  IsSupportedScriptExpression(this._expression)
+      : super('isSupportedScript(${_expression.cacheKey})', _expression.properties());
+
+  @override
+  evaluate(EvaluationContext context) {
+    final operand = _expression.evaluate(context);
+    if (operand is String) {
+      // At the moment, known rendering frontends utilizing this library make use of advanced
+      // text rendering stacks rather than SDF (per the historical approach of
+      // Mapbox and MapLibre), so complex shaping support is not an issue.
+      return true;
+    }
+    context.logger.warn(() => 'IsSupportedScriptExpression expected string but got $operand');
+    return null;
+  }
+
+  @override
+  bool get isConstant => _expression.isConstant;
+}

--- a/lib/src/themes/expression/is_supported_script_expression.dart
+++ b/lib/src/themes/expression/is_supported_script_expression.dart
@@ -6,7 +6,8 @@ class IsSupportedScriptExpression extends Expression {
   final Expression _expression;
 
   IsSupportedScriptExpression(this._expression)
-      : super('isSupportedScript(${_expression.cacheKey})', _expression.properties());
+      : super('isSupportedScript(${_expression.cacheKey})',
+            _expression.properties());
 
   @override
   evaluate(EvaluationContext context) {
@@ -27,7 +28,8 @@ class IsSupportedScriptExpression extends Expression {
       // C++: https://github.com/maplibre/maplibre-gl-native/blob/32ed70c95d734590b3e68cd4595a2806fd13c389/src/mbgl/util/i18n.cpp#L632
       return true;
     }
-    context.logger.warn(() => 'IsSupportedScriptExpression expected string but got $operand');
+    context.logger.warn(
+        () => 'IsSupportedScriptExpression expected string but got $operand');
     return null;
   }
 

--- a/lib/src/themes/expression/is_supported_script_expression.dart
+++ b/lib/src/themes/expression/is_supported_script_expression.dart
@@ -12,9 +12,19 @@ class IsSupportedScriptExpression extends Expression {
   evaluate(EvaluationContext context) {
     final operand = _expression.evaluate(context);
     if (operand is String) {
-      // At the moment, known rendering frontends utilizing this library make use of advanced
-      // text rendering stacks rather than SDF (per the historical approach of
-      // Mapbox and MapLibre), so complex shaping support is not an issue.
+      // Most MapLibre/Mapbox renderers use SDF glyph rendering, which has
+      // problems with scripts requiring complex text shaping (ex: Khmer,
+      // Nepalese, Burmese, Devanagari, etc.) and, in some cases, lack RTL support.
+      //
+      // At the moment, known rendering frontends utilizing this library, such
+      // as the flutter_map plugin, utilize more traditional font rendering
+      // approaches, so we can assume that all characters are supported.
+      //
+      // More about complex scripts: https://en.wikipedia.org/wiki/Complex_text_layout
+      //
+      // Canonical implementations for SDF-based renderers:
+      // JS: https://github.com/maplibre/maplibre-gl-js/blob/51054671229c68d798fa06a64968aa35688f6a0f/src/util/script_detection.ts#L319
+      // C++: https://github.com/maplibre/maplibre-gl-native/blob/32ed70c95d734590b3e68cd4595a2806fd13c389/src/mbgl/util/i18n.cpp#L632
       return true;
     }
     context.logger.warn(() => 'IsSupportedScriptExpression expected string but got $operand');

--- a/lib/src/themes/expression/is_supported_script_expression.dart
+++ b/lib/src/themes/expression/is_supported_script_expression.dart
@@ -1,5 +1,3 @@
-import 'package:flutter/widgets.dart';
-
 import 'expression.dart';
 
 class IsSupportedScriptExpression extends Expression {

--- a/lib/src/themes/expression/parser/boolean_operator_expression_parser.dart
+++ b/lib/src/themes/expression/parser/boolean_operator_expression_parser.dart
@@ -263,7 +263,8 @@ class CaseExpressionParser extends ExpressionComponentParser {
 }
 
 class IsSupportedScriptExpressionParser extends ExpressionComponentParser {
-  IsSupportedScriptExpressionParser(ExpressionParser parser) : super(parser, 'is-supported-script');
+  IsSupportedScriptExpressionParser(ExpressionParser parser)
+      : super(parser, 'is-supported-script');
 
   @override
   bool matches(List<dynamic> json) {

--- a/lib/src/themes/expression/parser/boolean_operator_expression_parser.dart
+++ b/lib/src/themes/expression/parser/boolean_operator_expression_parser.dart
@@ -1,6 +1,7 @@
 import '../case_expression.dart';
 import '../comparison_expression.dart';
 import '../expression.dart';
+import '../is_supported_script_expression.dart';
 import '../literal_expression.dart';
 import 'expression_parser.dart';
 
@@ -258,5 +259,23 @@ class CaseExpressionParser extends ExpressionComponentParser {
     }
     cases.add(ConditionOutputPair(LiteralExpression(true), fallbackOutput));
     return CaseExpression(cases);
+  }
+}
+
+class IsSupportedScriptExpressionParser extends ExpressionComponentParser {
+  IsSupportedScriptExpressionParser(ExpressionParser parser) : super(parser, 'is-supported-script');
+
+  @override
+  bool matches(List<dynamic> json) {
+    return super.matches(json) && json.length == 2;
+  }
+
+  @override
+  Expression? parse(List<dynamic> json) {
+    Expression? second = parser.parseOptionalPropertyOrExpression(json[1]);
+    if (second != null) {
+      return IsSupportedScriptExpression(second);
+    }
+    return null;
   }
 }

--- a/lib/src/themes/expression/parser/expression_parser.dart
+++ b/lib/src/themes/expression/parser/expression_parser.dart
@@ -59,6 +59,7 @@ class ExpressionParser {
     final varParser = VarExpressionParser(this);
     _register(varParser);
     _register(LetExpressionParser(this, varParser));
+    _register(IsSupportedScriptExpressionParser(this));
   }
 
   Set<String> supportedOperators() => _parserByOperator.keys.toSet();

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,91 +5,104 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      url: "https://pub.dartlang.org"
+      sha256: "0c80aeab9bc807ab10022cd3b2f4cf2ecdf231949dc1ddd9442406a003f19201"
+      url: "https://pub.dev"
     source: hosted
-    version: "41.0.0"
+    version: "52.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      url: "https://pub.dartlang.org"
+      sha256: cd8ee83568a77f3ae6b913a36093a1c9b1264e7cb7f834d9ddd2311dade9c1f4
+      url: "https://pub.dev"
     source: hosted
-    version: "4.2.0"
+    version: "5.4.0"
   args:
     dependency: transitive
     description:
       name: args
-      url: "https://pub.dartlang.org"
+      sha256: "139d809800a412ebb26a3892da228b2d0ba36f0ef5d9a82166e5e52ec8d61611"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.3.1"
+    version: "2.3.2"
   async:
     dependency: transitive
     description:
       name: async
-      url: "https://pub.dartlang.org"
+      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      url: "https://pub.dev"
     source: hosted
-    version: "2.9.0"
+    version: "2.10.0"
   benchmark_harness:
     dependency: "direct dev"
     description:
       name: benchmark_harness
-      url: "https://pub.dartlang.org"
+      sha256: "200beeddb5e8b3611ebb0bc8a730d63967afc3c9a5898791245eb46712a83a24"
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      url: "https://pub.dartlang.org"
+      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   characters:
     dependency: transitive
     description:
       name: characters
-      url: "https://pub.dartlang.org"
+      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
   collection:
     dependency: "direct main"
     description:
       name: collection
-      url: "https://pub.dartlang.org"
+      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   convert:
     dependency: transitive
     description:
       name: convert
-      url: "https://pub.dartlang.org"
+      sha256: "0f08b14755d163f6e2134cb58222dd25ea2a2ee8a195e53983d57c075324d592"
+      url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "3.1.1"
   coverage:
     dependency: transitive
     description:
       name: coverage
-      url: "https://pub.dartlang.org"
+      sha256: "961c4aebd27917269b1896382c7cb1b1ba81629ba669ba09c27a7e5710ec9040"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.5.0"
+    version: "1.6.2"
   crypto:
     dependency: transitive
     description:
       name: crypto
-      url: "https://pub.dartlang.org"
+      sha256: aa274aa7774f8964e4f4f38cc994db7b6158dd36e9187aaceaddc994b35c6c67
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
   file:
     dependency: transitive
     description:
       name: file
-      url: "https://pub.dartlang.org"
+      sha256: "1b92bec4fc2a72f59a8e15af5f52cd441e4a7860b49499d69dfa817af20e925d"
+      url: "https://pub.dev"
     source: hosted
-    version: "6.1.2"
+    version: "6.1.4"
   fixnum:
     dependency: "direct main"
     description:
       name: fixnum
-      url: "https://pub.dartlang.org"
+      sha256: "04be3e934c52e082558cc9ee21f42f5c1cd7a1262f4c63cd0357c08d5bba81ec"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
   flutter:
@@ -101,163 +114,186 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      url: "https://pub.dartlang.org"
+      sha256: aeb0b80a8b3709709c9cc496cdc027c5b3216796bc0af0ce1007eaf24464fd4c
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   frontend_server_client:
     dependency: transitive
     description:
       name: frontend_server_client
-      url: "https://pub.dartlang.org"
+      sha256: "408e3ca148b31c20282ad6f37ebfa6f4bdc8fede5b74bc2f08d9d92b55db3612"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.3"
+    version: "3.2.0"
   glob:
     dependency: transitive
     description:
       name: glob
-      url: "https://pub.dartlang.org"
+      sha256: "4515b5b6ddb505ebdd242a5f2cc5d22d3d6a80013789debfbda7777f47ea308c"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   http_multi_server:
     dependency: transitive
     description:
       name: http_multi_server
-      url: "https://pub.dartlang.org"
+      sha256: "97486f20f9c2f7be8f514851703d0119c3596d14ea63227af6f7a481ef2b2f8b"
+      url: "https://pub.dev"
     source: hosted
     version: "3.2.1"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
-      url: "https://pub.dartlang.org"
+      sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
+      url: "https://pub.dev"
     source: hosted
-    version: "4.0.1"
+    version: "4.0.2"
   io:
     dependency: transitive
     description:
       name: io
-      url: "https://pub.dartlang.org"
+      sha256: "2ec25704aba361659e10e3e5f5d672068d332fc8ac516421d483a11e5cbd061e"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.3"
+    version: "1.0.4"
   js:
     dependency: transitive
     description:
       name: js
-      url: "https://pub.dartlang.org"
+      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.6.4"
+    version: "0.6.5"
   lints:
     dependency: transitive
     description:
       name: lints
-      url: "https://pub.dartlang.org"
+      sha256: "5e4a9cd06d447758280a8ac2405101e0e2094d2a1dbdd3756aec3fe7775ba593"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "2.0.1"
   logging:
     dependency: transitive
     description:
       name: logging
-      url: "https://pub.dartlang.org"
+      sha256: "04094f2eb032cbb06c6f6e8d3607edcfcb0455e2bb6cbc010cb01171dcb64e6d"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.2"
+    version: "1.1.1"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      url: "https://pub.dartlang.org"
+      sha256: c94db23593b89766cda57aab9ac311e3616cf87c6fa4e9749df032f66f30dcb8
+      url: "https://pub.dev"
     source: hosted
-    version: "0.12.12"
+    version: "0.12.14"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      url: "https://pub.dartlang.org"
+      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      url: "https://pub.dev"
     source: hosted
-    version: "0.1.5"
+    version: "0.2.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      url: "https://pub.dev"
     source: hosted
     version: "1.8.0"
   mime:
     dependency: transitive
     description:
       name: mime
-      url: "https://pub.dartlang.org"
+      sha256: e4ff8e8564c03f255408decd16e7899da1733852a9110a58fe6d1b817684a63e
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.4"
   node_preamble:
     dependency: transitive
     description:
       name: node_preamble
-      url: "https://pub.dartlang.org"
+      sha256: "8ebdbaa3b96d5285d068f80772390d27c21e1fa10fb2df6627b1b9415043608d"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   package_config:
     dependency: transitive
     description:
       name: package_config
-      url: "https://pub.dartlang.org"
+      sha256: "1c5b77ccc91e4823a5af61ee74e6b972db1ef98c2ff5a18d3161c982a55448bd"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   path:
     dependency: transitive
     description:
       name: path
-      url: "https://pub.dartlang.org"
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.2"
+    version: "1.8.3"
   pool:
     dependency: transitive
     description:
       name: pool
-      url: "https://pub.dartlang.org"
+      sha256: "20fe868b6314b322ea036ba325e6fc0711a22948856475e2c2b6306e8ab39c2a"
+      url: "https://pub.dev"
     source: hosted
     version: "1.5.1"
   protobuf:
     dependency: transitive
     description:
       name: protobuf
-      url: "https://pub.dartlang.org"
+      sha256: "01dd9bd0fa02548bf2ceee13545d4a0ec6046459d847b6b061d8a27237108a08"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   pub_semver:
     dependency: transitive
     description:
       name: pub_semver
-      url: "https://pub.dartlang.org"
+      sha256: "307de764d305289ff24ad257ad5c5793ce56d04947599ad68b3baa124105fc17"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.3"
   shelf:
     dependency: transitive
     description:
       name: shelf
-      url: "https://pub.dartlang.org"
+      sha256: c24a96135a2ccd62c64b69315a14adc5c3419df63b4d7c05832a346fdb73682c
+      url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.4.0"
   shelf_packages_handler:
     dependency: transitive
     description:
       name: shelf_packages_handler
-      url: "https://pub.dartlang.org"
+      sha256: aef74dc9195746a384843102142ab65b6a4735bb3beea791e63527b88cc83306
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.1"
   shelf_static:
     dependency: transitive
     description:
       name: shelf_static
-      url: "https://pub.dartlang.org"
+      sha256: e792b76b96a36d4a41b819da593aff4bdd413576b3ba6150df5d8d9996d2e74c
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
-      url: "https://pub.dartlang.org"
+      sha256: a988c0e8d8ffbdb8a28aa7ec8e449c260f3deb808781fe1284d22c5bba7156e8
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.3"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -267,128 +303,146 @@ packages:
     dependency: transitive
     description:
       name: source_map_stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: "84cf769ad83aa6bb61e0aa5a18e53aea683395f196a6f39c4c881fb90ed4f7ae"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   source_maps:
     dependency: transitive
     description:
       name: source_maps
-      url: "https://pub.dartlang.org"
+      sha256: "490098075234dcedb83c5d949b4c93dad5e6b7702748de000be2b57b8e6b2427"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.10.10"
+    version: "0.10.11"
   source_span:
     dependency: transitive
     description:
       name: source_span
-      url: "https://pub.dartlang.org"
+      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      url: "https://pub.dartlang.org"
+      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      url: "https://pub.dartlang.org"
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.2.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      url: "https://pub.dartlang.org"
+      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
   test:
     dependency: "direct dev"
     description:
       name: test
-      url: "https://pub.dartlang.org"
+      sha256: b54d427664c00f2013ffb87797a698883c46aee9288e027a50b46eaee7486fa2
+      url: "https://pub.dev"
     source: hosted
-    version: "1.21.4"
+    version: "1.22.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      url: "https://pub.dartlang.org"
+      sha256: "6182294da5abf431177fccc1ee02401f6df30f766bc6130a0852c6b6d7ee6b2d"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.4.12"
+    version: "0.4.18"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      url: "https://pub.dartlang.org"
+      sha256: "95ecc12692d0dd59080ab2d38d9cf32c7e9844caba23ff6cd285690398ee8ef4"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.4.16"
+    version: "0.4.22"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
-      url: "https://pub.dartlang.org"
+      sha256: "26f87ade979c47a150c9eaab93ccd2bebe70a27dc0b4b29517f2904f04eb11a5"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      url: "https://pub.dartlang.org"
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
   vector_tile:
     dependency: "direct main"
     description:
       name: vector_tile
-      url: "https://pub.dartlang.org"
+      sha256: "2ac77f6bbd7ddd97efe059207d67bb7eaf807ab98ad58d99fe41a22c230f44e1"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
-      url: "https://pub.dartlang.org"
+      sha256: d069ad658b700fc5fb774771ac8997f226ca29a45e0a450776fff3d969c8ba8f
+      url: "https://pub.dev"
     source: hosted
-    version: "9.0.0"
+    version: "10.1.0"
   watcher:
     dependency: transitive
     description:
       name: watcher
-      url: "https://pub.dartlang.org"
+      sha256: "6a7f46926b01ce81bfc339da6a7f20afbe7733eff9846f6d6a5466aa4c6667c0"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.1"
+    version: "1.0.2"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      url: "https://pub.dartlang.org"
+      sha256: ca49c0bc209c687b887f30527fb6a9d80040b072cc2990f34b9bec3e7663101b
+      url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.3.0"
   webkit_inspection_protocol:
     dependency: transitive
     description:
       name: webkit_inspection_protocol
-      url: "https://pub.dartlang.org"
+      sha256: "67d3a8b6c79e1987d19d848b0892e582dbb0c66c57cc1fef58a177dd2aa2823d"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   yaml:
     dependency: transitive
     description:
       name: yaml
-      url: "https://pub.dartlang.org"
+      sha256: "23812a9b125b48d4007117254bca50abb6c712352927eece9e155207b1db2370"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.17.0 <3.0.0"
+  dart: ">=2.18.0 <4.0.0"
   flutter: ">=2.14.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: vector_tile_renderer
 description: A vector tile renderer for use in creating map tile images or writing to a canvas.
-version: 3.0.4
+version: 3.1.0
 homepage: https://github.com/greensopinion/dart-vector-tile-renderer
 
 environment:

--- a/test/src/themes/expression/expression_parser_test.dart
+++ b/test/src/themes/expression/expression_parser_test.dart
@@ -389,15 +389,32 @@ void main() {
           true);
     });
 
-    test('parses an is-supported-script expression for latin script strings', () {
-      assertExpression(['is-supported-script', ['get', 'a-string']], 'isSupportedScript(get(a-string))', true);
-      assertExpression(['is-supported-script', ['get', 'a-latin-ligature']], 'isSupportedScript(get(a-latin-ligature))', true);
+    test('parses an is-supported-script expression for latin script strings',
+        () {
+      assertExpression([
+        'is-supported-script',
+        ['get', 'a-string']
+      ], 'isSupportedScript(get(a-string))', true);
+      assertExpression([
+        'is-supported-script',
+        ['get', 'a-latin-ligature']
+      ], 'isSupportedScript(get(a-latin-ligature))', true);
     });
 
-    test('parses an is-supported-script expression for complex script strings', () {
-      assertExpression(['is-supported-script', ['get', 'a-bengali-string']], 'isSupportedScript(get(a-bengali-string))', true);
-      assertExpression(['is-supported-script', ['get', 'a-burmese-string']], 'isSupportedScript(get(a-burmese-string))', true);
-      assertExpression(['is-supported-script', ['get', 'a-khmer-string']], 'isSupportedScript(get(a-khmer-string))', true);
+    test('parses an is-supported-script expression for complex script strings',
+        () {
+      assertExpression([
+        'is-supported-script',
+        ['get', 'a-bengali-string']
+      ], 'isSupportedScript(get(a-bengali-string))', true);
+      assertExpression([
+        'is-supported-script',
+        ['get', 'a-burmese-string']
+      ], 'isSupportedScript(get(a-burmese-string))', true);
+      assertExpression([
+        'is-supported-script',
+        ['get', 'a-khmer-string']
+      ], 'isSupportedScript(get(a-khmer-string))', true);
     });
   });
   group('math expressions:', () {

--- a/test/src/themes/expression/expression_parser_test.dart
+++ b/test/src/themes/expression/expression_parser_test.dart
@@ -8,6 +8,10 @@ void main() {
   final properties = {
     'a-string': 'a-string-value',
     'another-string': 'another-string-value',
+    'a-latin-ligature': 'ﬁ',
+    'a-bengali-string': 'বাংলা',
+    'a-burmese-string': 'မြန်မာဘာသာ',
+    'a-khmer-string': 'អក្សរខ្មែរ',
     'a-bool': true,
     'a-false-bool': false,
     'an-int': 33,
@@ -68,6 +72,7 @@ void main() {
           'has',
           'in',
           'interpolate',
+          'is-supported-script',
           'let',
           'match',
           'step',
@@ -382,6 +387,17 @@ void main() {
         true
       ], 'match(get(another-string),[literal(no-match-value),literal(a-string-value)],[literal(another-no-match-value)],literal(false),literal(false),literal(true))',
           true);
+    });
+
+    test('parses an is-supported-script expression for latin script strings', () {
+      assertExpression(['is-supported-script', ['get', 'a-string']], 'isSupportedScript(get(a-string))', true);
+      assertExpression(['is-supported-script', ['get', 'a-latin-ligature']], 'isSupportedScript(get(a-latin-ligature))', true);
+    });
+
+    test('parses an is-supported-script expression for complex script strings', () {
+      assertExpression(['is-supported-script', ['get', 'a-bengali-string']], 'isSupportedScript(get(a-bengali-string))', true);
+      assertExpression(['is-supported-script', ['get', 'a-burmese-string']], 'isSupportedScript(get(a-burmese-string))', true);
+      assertExpression(['is-supported-script', ['get', 'a-khmer-string']], 'isSupportedScript(get(a-khmer-string))', true);
     });
   });
   group('math expressions:', () {


### PR DESCRIPTION
Closes https://github.com/greensopinion/flutter-vector-map-tiles/issues/113.

I have tested this on a variety of complex shaping scripts such as Nepalese, Burmese, and Khmer, as well as RTL languages such as Arabic and Hebrew. These are the standard problem cases for text rendering, and it appears to pass as a result of not using SDF glyph rendering like most other "modern" renderers, which is pretty cool! As such, the implementation turned out to be pretty simple.