### PR TITLE
improve curly brace expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.2.1
+
+* fix an issue where curly brace expressions referencing a non-string property value could not be rendered as text
+
 ## 3.2.0
 
 * add support for `to-boolean` expressions

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -198,7 +198,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "3.2.0"
+    version: "3.2.1"
 sdks:
   dart: ">=2.18.0 <3.0.0"
   flutter: ">=2.14.0"

--- a/lib/src/themes/expression/parser/expression_parser.dart
+++ b/lib/src/themes/expression/parser/expression_parser.dart
@@ -172,7 +172,7 @@ class ExpressionParser {
     if (match != null) {
       final propertyName = match.group(1);
       if (propertyName != null) {
-        return GetPropertyExpression(propertyName);
+        return ToStringExpression(GetPropertyExpression(propertyName));
       }
     }
     return LiteralExpression(json);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: vector_tile_renderer
 description: A vector tile renderer for use in creating map tile images or writing to a canvas.
-version: 3.2.0
+version: 3.2.1
 homepage: https://github.com/greensopinion/dart-vector-tile-renderer
 
 environment:

--- a/test/src/themes/expression/expression_parser_test.dart
+++ b/test/src/themes/expression/expression_parser_test.dart
@@ -190,8 +190,10 @@ void main() {
     }
 
     test('parses a formatted string', () {
-      assertExpression('{a-string}', 'get(a-string)', 'a-string-value');
-      assertExpression('{no-match}', 'get(no-match)', null);
+      assertExpression(
+          '{a-string}', 'toString(get(a-string))', 'a-string-value');
+      assertExpression('{no-match}', 'toString(get(no-match))', '');
+      assertExpression('{an-int}', 'toString(get(an-int))', '33');
     });
 
     test('parses a get property', () {


### PR DESCRIPTION
Fix a problem where curly-brace expressions
referencing non-string properties could not
be rendered as text on a map.