### PR TITLE
fix: gracefully handle bad polygon

### DIFF
--- a/lib/src/model/geometry_decoding.dart
+++ b/lib/src/model/geometry_decoding.dart
@@ -161,7 +161,7 @@ Iterable<TilePolygon> decodePolygons(List<int> geometry) {
 
       // Add the ring to the current polygon.
       rings ??= [TileLine([])];
-      rings!.add(TileLine(points));
+      rings.add(TileLine(points));
     } else {
       // We just decoded an exterior ring.
 

--- a/lib/src/model/geometry_decoding.dart
+++ b/lib/src/model/geometry_decoding.dart
@@ -160,7 +160,7 @@ Iterable<TilePolygon> decodePolygons(List<int> geometry) {
       // We just decoded an interior ring.
 
       // Add the ring to the current polygon.
-      assert(rings != null);
+      rings ??= [TileLine([])];
       rings!.add(TileLine(points));
     } else {
       // We just decoded an exterior ring.


### PR DESCRIPTION
Map-Providers may occassionally have bad data with a negative polygon as start. Currently the null-assertion causes a blank tile to be rendered in this case with little for the developer to do against it (unless they host the tile-server which is a rare occurence, I would assume).

This PR aims to solve this by falling back to an empty TileLine as first element should the first line be negative. This way nothing is rendered with minimal disturbance to the rest of the rendering process while avoiding an error to be thrown at runtime that causes a completely blank tile.