### PR TITLE
add categorical expression

### DIFF
--- a/lib/src/themes/expression/parser/categorical_expression_parser.dart
+++ b/lib/src/themes/expression/parser/categorical_expression_parser.dart
@@ -9,6 +9,16 @@ class CategoricalExpressionParser extends ExpressionComponentParser {
 
   @override
   Expression? parse(List<dynamic> json) {
+    // [0] expression type
+    // [1] property name
+    // [2] default value
+    // [3:] pair of stops
+    if (json.length < 3 || json.length.isEven) {
+      throw Exception(
+        'The amount of categorical expression of the theme is malformed',
+      );
+    }
+
     return CategoricalPropertyExpression(
       propertyName: json[1],
       defaultValue: json[2],

--- a/lib/src/themes/expression/parser/categorical_expression_parser.dart
+++ b/lib/src/themes/expression/parser/categorical_expression_parser.dart
@@ -1,0 +1,18 @@
+import 'package:vector_tile_renderer/src/themes/expression/property_expression.dart';
+
+import '../expression.dart';
+import 'expression_parser.dart';
+
+class CategoricalExpressionParser extends ExpressionComponentParser {
+  CategoricalExpressionParser(ExpressionParser parser)
+      : super(parser, 'categorical');
+
+  @override
+  Expression? parse(List<dynamic> json) {
+    return CategoricalPropertyExpression(
+      propertyName: json[1],
+      defaultValue: json[2],
+      stops: json.sublist(3),
+    );
+  }
+}

--- a/lib/src/themes/expression/parser/expression_parser.dart
+++ b/lib/src/themes/expression/parser/expression_parser.dart
@@ -99,26 +99,23 @@ class ExpressionParser {
       }
     }
     if (json is Map) {
-      // legacy categorical expressions
-      // https://docs.mapbox.com/style-spec/reference/other
-      if (json['type'] == 'categorical') {
-        final property = parseOptional(json['property']);
-        if (property == null) {
-          return null;
-        }
-        final stops = json['stops'];
-        final defaultValue = json['default'];
-        return parseOptional([
-          'categorical',
-          property,
-          defaultValue,
-          ..._flattenStops(stops),
-        ]);
-      }
-
-      final base = json['base'] ?? 1;
       final stops = json['stops'];
       if (stops is List) {
+        if (json['type'] == 'categorical') {
+          // legacy categorical expressions
+          // https://docs.mapbox.com/style-spec/reference/other
+          final property = parseOptional(json['property']);
+          if (property == null) return null;
+
+          return parseOptional([
+            'categorical',
+            property,
+            json['default'],
+            ..._flattenStops(stops),
+          ]);
+        }
+
+        final base = json['base'] ?? 1;
         if (base == 1) {
           return parseOptional([
             'interpolate',

--- a/lib/src/themes/expression/parser/expression_parser.dart
+++ b/lib/src/themes/expression/parser/expression_parser.dart
@@ -114,7 +114,7 @@ class ExpressionParser {
           'categorical',
           property,
           defaultValue,
-          ..._flattenStops(stops)
+          ..._flattenStops(stops),
         ]);
       }
 

--- a/lib/src/themes/expression/parser/expression_parser.dart
+++ b/lib/src/themes/expression/parser/expression_parser.dart
@@ -110,7 +110,7 @@ class ExpressionParser {
           return parseOptional([
             'categorical',
             property,
-            json['default'],
+            parseOptional(json['default']),
             ..._flattenStops(stops),
           ]);
         }

--- a/lib/src/themes/expression/parser/expression_parser.dart
+++ b/lib/src/themes/expression/parser/expression_parser.dart
@@ -96,6 +96,13 @@ class ExpressionParser {
       }
     }
     if (json is Map) {
+      if (json['type'] == 'categorical') {
+        final property = json['property'];
+        final stops = json['stops'];
+        final defaultValue = json['default'];
+        return CategoricalPropertyExpression(property, defaultValue, stops);
+      }
+
       final base = json['base'] ?? 1;
       final stops = json['stops'];
       if (stops is List) {

--- a/lib/src/themes/expression/parser/expression_parser.dart
+++ b/lib/src/themes/expression/parser/expression_parser.dart
@@ -102,10 +102,8 @@ class ExpressionParser {
       // legacy categorical expressions
       // https://docs.mapbox.com/style-spec/reference/other
       if (json['type'] == 'categorical') {
-        final property = json['property'];
-        if (property is! String?) {
-          logger.warn(() =>
-              'Malformed categorical expression, property field must be an optional String: $json');
+        final property = parseOptional(json['property']);
+        if (property == null) {
           return null;
         }
         final stops = json['stops'];

--- a/lib/src/themes/expression/property_expression.dart
+++ b/lib/src/themes/expression/property_expression.dart
@@ -45,11 +45,6 @@ class CategoricalPropertyExpression extends Expression {
   evaluate(EvaluationContext context) {
     if (propertyName?.isEmpty ?? true) return null;
 
-    if (!stops.length.isEven) {
-      context.logger.warn(() => 'Could not parse categorical stops: $stops');
-      return null;
-    }
-
     final propertyValue = context.getProperty(propertyName!);
     var tmpResult = defaultValue;
     for (var i = 0; i < stops.length; i += 2) {

--- a/lib/src/themes/expression/property_expression.dart
+++ b/lib/src/themes/expression/property_expression.dart
@@ -12,3 +12,33 @@ class GetPropertyExpression extends Expression {
   @override
   bool get isConstant => false;
 }
+
+class CategoricalPropertyExpression extends Expression {
+  final String _propertyName;
+  final String? _default;
+  final List _stops;
+
+  CategoricalPropertyExpression(this._propertyName, this._default, this._stops)
+      : super('categorical($_propertyName, $_stops)', {_propertyName});
+
+  @override
+  evaluate(EvaluationContext context) {
+    final propertyValue = context.getProperty(_propertyName);
+    String? tmpResult = _default;
+    for (final stop in _stops) {
+      if (stop is! List || stop.length != 2) {
+        context.logger.warn(() => 'Could not parse categorical stop: $stop');
+        continue;
+      }
+      final Map<String, dynamic> property = stop[0];
+      if (property['zoom'] > context.zoom) break;
+      if (property['value'] == propertyValue) {
+        tmpResult = stop[1];
+      }
+    }
+    return tmpResult;
+  }
+
+  @override
+  bool get isConstant => false;
+}

--- a/lib/src/themes/expression/property_expression.dart
+++ b/lib/src/themes/expression/property_expression.dart
@@ -52,7 +52,7 @@ class CategoricalPropertyExpression extends Expression {
 
     final propertyValue = context.getProperty(propertyName!);
     var tmpResult = defaultValue;
-    for (var i = 0; i<stops.length; i += 2) {
+    for (var i = 0; i < stops.length; i += 2) {
       final input = stops[i];
       final inputZoom = input['zoom'];
       final output = stops[i + 1];

--- a/lib/src/themes/expression/property_expression.dart
+++ b/lib/src/themes/expression/property_expression.dart
@@ -1,4 +1,5 @@
 import 'expression.dart';
+import 'literal_expression.dart';
 
 class GetPropertyExpression extends Expression {
   final String _propertyName;
@@ -23,10 +24,10 @@ class GetPropertyExpression extends Expression {
 class CategoricalPropertyExpression extends Expression {
   /// If specified, the function will take the specified feature property
   /// as an input.
-  final String? propertyName;
+  final LiteralExpression? propertyName;
 
   /// When the feature value does not match any of the stop domain values.
-  final dynamic defaultValue;
+  final LiteralExpression? defaultValue;
 
   /// An alternating list of one input and one output value. Stop output
   /// values must be literal values (in other words not functions or
@@ -43,10 +44,11 @@ class CategoricalPropertyExpression extends Expression {
 
   @override
   evaluate(EvaluationContext context) {
-    if (propertyName?.isEmpty ?? true) return null;
+    final propertyName = this.propertyName?.evaluate(context);
+    if (propertyName == null) return defaultValue?.evaluate(context);
 
     final propertyValue = context.getProperty(propertyName!);
-    var tmpResult = defaultValue;
+    dynamic tmpResult;
     for (var i = 0; i < stops.length; i += 2) {
       final input = stops[i];
       final inputZoom = input['zoom'];
@@ -58,7 +60,7 @@ class CategoricalPropertyExpression extends Expression {
         tmpResult = output;
       }
     }
-    return tmpResult;
+    return tmpResult ?? defaultValue?.evaluate(context);
   }
 
   @override

--- a/lib/src/themes/expression/property_expression.dart
+++ b/lib/src/themes/expression/property_expression.dart
@@ -50,10 +50,10 @@ class CategoricalPropertyExpression extends Expression {
     for (var i = 0; i < stops.length; i += 2) {
       final input = stops[i];
       final inputZoom = input['zoom'];
-      final output = stops[i + 1];
       if (inputZoom is! int) continue;
-
       if (input['zoom'] > context.zoom) break;
+
+      final output = stops[i + 1];
       if (input['value'] == propertyValue) {
         tmpResult = output;
       }

--- a/lib/src/themes/expression/property_expression.dart
+++ b/lib/src/themes/expression/property_expression.dart
@@ -13,27 +13,54 @@ class GetPropertyExpression extends Expression {
   bool get isConstant => false;
 }
 
+/// A function that returns the output value of the stop equal to the
+/// function input.
+///
+/// As of v0.41.0, property expressions is the preferred method for
+/// styling features based on zoom level or the feature's properties.
+/// Zoom and property functions will be phased out in a future
+/// style specification.
 class CategoricalPropertyExpression extends Expression {
-  final String _propertyName;
-  final String? _default;
-  final List _stops;
+  /// If specified, the function will take the specified feature property
+  /// as an input.
+  final String? propertyName;
 
-  CategoricalPropertyExpression(this._propertyName, this._default, this._stops)
-      : super('categorical($_propertyName, $_stops)', {_propertyName});
+  /// When the feature value does not match any of the stop domain values.
+  final dynamic defaultValue;
+
+  /// An alternating list of one input and one output value. Stop output
+  /// values must be literal values (in other words not functions or
+  /// expressions), and appropriate for the property. For example, stop output
+  /// values for a fill-color function property must be colors.
+  final List stops;
+
+  CategoricalPropertyExpression({
+    required this.propertyName,
+    required this.defaultValue,
+    required this.stops,
+  }) : super('categorical($propertyName)',
+            stops.map((e) => e.toString()).toSet());
 
   @override
   evaluate(EvaluationContext context) {
-    final propertyValue = context.getProperty(_propertyName);
-    String? tmpResult = _default;
-    for (final stop in _stops) {
-      if (stop is! List || stop.length != 2) {
-        context.logger.warn(() => 'Could not parse categorical stop: $stop');
-        continue;
-      }
-      final Map<String, dynamic> property = stop[0];
-      if (property['zoom'] > context.zoom) break;
-      if (property['value'] == propertyValue) {
-        tmpResult = stop[1];
+    if (propertyName?.isEmpty ?? true) return null;
+
+    if (!stops.length.isEven) {
+      context.logger.warn(() => 'Could not parse categorical stops: $stops');
+      return null;
+    }
+
+    final propertyValue = context.getProperty(propertyName!);
+    var tmpResult = defaultValue;
+    for (var i = 0; i<stops.length; i += 2) {
+      final input = stops[i];
+      final inputZoom = input['zoom'];
+      final output = stops[i + 1];
+      if (inputZoom is! int) continue;
+
+      if (input['zoom'] > context.zoom) break;
+      if (input['value'] == propertyValue) {
+        tmpResult = output;
       }
     }
     return tmpResult;

--- a/test/src/themes/expression/expression_parser_test.dart
+++ b/test/src/themes/expression/expression_parser_test.dart
@@ -827,7 +827,7 @@ void main() {
       "default": "Restrooms"
     };
     const expectedCacheKey =
-        'categorical(seamark:small_craft_facility:category)';
+        'categorical(literal(seamark:small_craft_facility:category))';
     zoom = 0;
     test('provides categorical expression that evaluates to a fallback', () {
       properties["seamark:small_craft_facility:category"] = "SomethingRandom";

--- a/test/src/themes/expression/expression_parser_test.dart
+++ b/test/src/themes/expression/expression_parser_test.dart
@@ -68,6 +68,7 @@ void main() {
           'all',
           'any',
           'case',
+          'categorical',
           'coalesce',
           'concat',
           'geometry-type',
@@ -85,7 +86,7 @@ void main() {
           'to-boolean',
           'to-number',
           'to-string',
-          'var'
+          'var',
         ]));
   });
 
@@ -807,6 +808,43 @@ void main() {
     test('provides case expression that evaluates to another case', () {
       zoom = 4;
       assertExpression(expression, expectedCacheKey, 2);
+    });
+  });
+  group('categorical expression:', () {
+    final expression = {
+      "property": "seamark:small_craft_facility:category",
+      "type": "categorical",
+      "stops": [
+        [
+          {"zoom": 0, "value": "showers"},
+          "Showers"
+        ],
+        [
+          {"zoom": 0, "value": "launderette"},
+          "Launderette"
+        ],
+      ],
+      "default": "Restrooms"
+    };
+    const expectedCacheKey =
+        'categorical(seamark:small_craft_facility:category)';
+    zoom = 0;
+    test('provides categorical expression that evaluates to a fallback', () {
+      properties["seamark:small_craft_facility:category"] = "SomethingRandom";
+      assertExpression(expression, expectedCacheKey, "Restrooms");
+    });
+    test(
+        'provides categorical expression if property is not set which evaluates to a fallback',
+        () {
+      assertExpression(expression, expectedCacheKey, "Restrooms");
+    });
+    test('provides categorical expression that evaluates to a first case', () {
+      properties["seamark:small_craft_facility:category"] = "showers";
+      assertExpression(expression, expectedCacheKey, "Showers");
+    });
+    test('provides categorical expression that evaluates to another case', () {
+      properties["seamark:small_craft_facility:category"] = "launderette";
+      assertExpression(expression, expectedCacheKey, "Launderette");
     });
   });
 }


### PR DESCRIPTION
This pull request adds support for categorical expressions.

Example JSON snippet for a categorical expression:
```json
"icon-image": {
      "property": "seamark:small_craft_facility:category",
      "type": "categorical",
      "stops": [
        [
          {
            "zoom": 0,
            "value": "showers"
          },
          "Showers"
        ],
        [
          {
            "zoom": 0,
            "value": "launderette"
          },
          "Launderette"
        ]
      ]
```