### PR TITLE
Draw lines and background on the GPU

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -38,7 +38,7 @@ class _MyHomePageState extends State<MyHomePage> {
   late TextEditingController _clipOffsetY;
   late TextEditingController _clipSize;
   TileOptions options = TileOptions(
-      size: const Size(256, 256),
+      size: const Size(512, 512),
       scale: 1.0,
       zoom: 15,
       xOffset: 0,

--- a/example/macos/Runner.xcodeproj/project.pbxproj
+++ b/example/macos/Runner.xcodeproj/project.pbxproj
@@ -360,10 +360,10 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/DebugProfile.entitlements;
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = 2J9XYBV642;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -488,10 +488,10 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/DebugProfile.entitlements;
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = 2J9XYBV642;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -510,10 +510,10 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = Runner/Release.entitlements;
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = 553X24H9D7;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Runner/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/lib/src/gpu/TODO.txt
+++ b/lib/src/gpu/TODO.txt
@@ -1,0 +1,5 @@
+
+
+Lines:
+ - Ensure that line points don't overflow the array buffer
+ - Fix scaling to use actual extent/tile size instead of hard coded values

--- a/lib/src/gpu/TODO.txt
+++ b/lib/src/gpu/TODO.txt
@@ -2,4 +2,4 @@
 
 Lines:
  - Ensure that line points don't overflow the array buffer
- - Fix scaling to use actual extent/tile size instead of hard coded scalars
+ - Fix line width to scale with actual extent/tile size instead of hard coded value

--- a/lib/src/gpu/TODO.txt
+++ b/lib/src/gpu/TODO.txt
@@ -2,4 +2,4 @@
 
 Lines:
  - Ensure that line points don't overflow the array buffer
- - Fix scaling to use actual extent/tile size instead of hard coded values
+ - Fix scaling to use actual extent/tile size instead of hard coded scalars

--- a/lib/src/gpu/background_geometry.dart
+++ b/lib/src/gpu/background_geometry.dart
@@ -1,0 +1,26 @@
+
+import 'dart:typed_data';
+import 'package:flutter_gpu/gpu.dart' as gpu;
+import 'package:flutter_scene/scene.dart';
+import 'package:vector_tile_renderer/src/gpu/shaders.dart';
+
+class BackgroundGeometry extends UnskinnedGeometry {
+
+  BackgroundGeometry() {
+    setVertexShader(shaderLibrary["SimpleVertex"]!);
+
+    List<double> vertices = [
+      -1, -1,  0,
+       1, -1,  0,
+       1,  1,  0,
+      -1,  1,  0
+    ];
+
+    uploadVertexData(
+      ByteData.sublistView(Float32List.fromList(vertices)),
+      4,
+      ByteData.sublistView(Uint16List.fromList([0,1,2,2,3,0])),
+      indexType: gpu.IndexType.int16,
+    );
+  }
+}

--- a/lib/src/gpu/colored_material.dart
+++ b/lib/src/gpu/colored_material.dart
@@ -6,10 +6,10 @@ import 'package:flutter_scene/scene.dart';
 import 'package:vector_math/vector_math.dart';
 import 'package:vector_tile_renderer/src/gpu/shaders.dart';
 
-class LineMaterial extends Material {
+class ColoredMaterial extends Material {
   Vector4 color;
 
-  LineMaterial(this.color) {
+  ColoredMaterial(this.color) {
     setFragmentShader(shaderLibrary["SimpleFragment"]!);
   }
 

--- a/lib/src/gpu/line_geometry.dart
+++ b/lib/src/gpu/line_geometry.dart
@@ -56,10 +56,12 @@ class LineGeometry extends UnskinnedGeometry {
 
     bindPositions(transientsBuffer, pass);
     bindLineStyle(transientsBuffer, pass);
+
+    pass.setPrimitiveType(gpu.PrimitiveType.triangle);
   }
 
   void bindPositions(HostBuffer transientsBuffer, RenderPass pass) {
-    final linePositions = Float32List.fromList(points.map((it) => [(it.x / 2048) - 1, 1 - (it.y / 2048)]).flattened.toList());
+    final linePositions = Float32List.fromList(points.map((it) => [(it.x / 2048) - 1, 1 - (it.y / 2048), 0.0, 0.0]).flattened.toList());
     final linePositionsSlot = vertexShader.getUniformSlot('LinePositions');
 
     final linePositionsView = transientsBuffer.emplace(

--- a/lib/src/gpu/line_geometry.dart
+++ b/lib/src/gpu/line_geometry.dart
@@ -20,16 +20,19 @@ class LineGeometry extends UnskinnedGeometry {
       List<double> vertices = List.empty(growable: true);
       List<int> indices = List.empty(growable: true);
 
+      const double above = 1;
+      const double below = -1;
+
       final segmentCount = pointCount - 1;
 
       for (int i = 0; i < segmentCount; i++) {
         double p0 = i + 0;
         double p1 = i + 1;
 
-        vertices.addAll([p1, 1, p0]);
-        vertices.addAll([p0, 1, p1]);
-        vertices.addAll([p0, 0, p1]);
-        vertices.addAll([p1, 0, p0]);
+        vertices.addAll([p1, above, p0]);
+        vertices.addAll([p0, above, p1]);
+        vertices.addAll([p0, below, p1]);
+        vertices.addAll([p1, below, p0]);
 
         indices.addAll([
           0, 1, 2, 2, 3, 0

--- a/lib/src/gpu/line_geometry.dart
+++ b/lib/src/gpu/line_geometry.dart
@@ -11,8 +11,9 @@ import 'package:vector_tile_renderer/src/gpu/shaders.dart';
 
 class LineGeometry extends UnskinnedGeometry {
   final Iterable<Point<double>> points;
+  double lineWidth;
 
-  LineGeometry(this.points) {
+  LineGeometry(this.points, this.lineWidth) {
     setVertexShader(shaderLibrary["LineVertex"]!);
 
     final pointCount = points.length;
@@ -53,6 +54,10 @@ class LineGeometry extends UnskinnedGeometry {
   void bind(RenderPass pass, HostBuffer transientsBuffer, Matrix4 modelTransform, Matrix4 cameraTransform, Vector3 cameraPosition) {
     super.bind(pass, transientsBuffer, modelTransform, cameraTransform, cameraPosition);
 
+    bindPositions(transientsBuffer, pass);
+  }
+
+  void bindPositions(HostBuffer transientsBuffer, RenderPass pass) {
     final linePositions = Float32List.fromList(points.map((it) => [it.x, it.y]).flattened.toList());
     final linePositionsSlot = vertexShader.getUniformSlot('LinePositions');
 
@@ -61,5 +66,11 @@ class LineGeometry extends UnskinnedGeometry {
     );
 
     pass.bindUniform(linePositionsSlot, linePositionsView);
+  }
+
+  void bindLineStyle(HostBuffer transientsBuffer, RenderPass pass) {
+    final lineStyleSlot = vertexShader.getUniformSlot('LineStyle');
+    final lineStyleView = transientsBuffer.emplace(Float32List.fromList([lineWidth]).buffer.asByteData());
+    pass.bindUniform(lineStyleSlot, lineStyleView);
   }
 }

--- a/lib/src/gpu/line_geometry.dart
+++ b/lib/src/gpu/line_geometry.dart
@@ -11,9 +11,10 @@ import 'package:vector_tile_renderer/src/gpu/shaders.dart';
 
 class LineGeometry extends UnskinnedGeometry {
   final Iterable<Point<double>> points;
-  double lineWidth;
+  final double lineWidth;
+  final int extent;
 
-  LineGeometry(this.points, this.lineWidth) {
+  LineGeometry({required this.points, required this.lineWidth, required this.extent}) {
     setVertexShader(shaderLibrary["LineVertex"]!);
 
     final pointCount = points.length;
@@ -61,7 +62,8 @@ class LineGeometry extends UnskinnedGeometry {
   }
 
   void bindPositions(HostBuffer transientsBuffer, RenderPass pass) {
-    final linePositions = Float32List.fromList(points.map((it) => [(it.x / 2048) - 1, 1 - (it.y / 2048), 0.0, 0.0]).flattened.toList());
+    final double extentScale = 2 / extent;
+    final linePositions = Float32List.fromList(points.map((it) => [(it.x * extentScale) - 1, 1 - (it.y * extentScale), 0.0, 0.0]).flattened.toList());
     final linePositionsSlot = vertexShader.getUniformSlot('LinePositions');
 
     final linePositionsView = transientsBuffer.emplace(

--- a/lib/src/gpu/line_geometry.dart
+++ b/lib/src/gpu/line_geometry.dart
@@ -31,8 +31,8 @@ class LineGeometry extends UnskinnedGeometry {
         double p1 = i + 1;
 
         vertices.addAll([p1, above, p0]);
-        vertices.addAll([p0, above, p1]);
         vertices.addAll([p0, below, p1]);
+        vertices.addAll([p0, above, p1]);
         vertices.addAll([p1, below, p0]);
 
         indices.addAll([

--- a/lib/src/gpu/line_geometry.dart
+++ b/lib/src/gpu/line_geometry.dart
@@ -73,7 +73,7 @@ class LineGeometry extends UnskinnedGeometry {
 
   void bindLineStyle(HostBuffer transientsBuffer, RenderPass pass) {
     final lineStyleSlot = vertexShader.getUniformSlot('LineStyle');
-    final lineStyleView = transientsBuffer.emplace(Float32List.fromList([lineWidth / 2048]).buffer.asByteData());
+    final lineStyleView = transientsBuffer.emplace(Float32List.fromList([lineWidth / 512]).buffer.asByteData());
     pass.bindUniform(lineStyleSlot, lineStyleView);
   }
 }

--- a/lib/src/gpu/line_geometry.dart
+++ b/lib/src/gpu/line_geometry.dart
@@ -42,7 +42,7 @@ class LineGeometry extends UnskinnedGeometry {
 
       uploadVertexData(
         ByteData.sublistView(Float32List.fromList(vertices)),
-        8,
+        segmentCount * 4,
         ByteData.sublistView(Uint16List.fromList(indices)),
         indexType: gpu.IndexType.int16,
       );
@@ -59,11 +59,11 @@ class LineGeometry extends UnskinnedGeometry {
   }
 
   void bindPositions(HostBuffer transientsBuffer, RenderPass pass) {
-    final linePositions = Float32List.fromList(points.map((it) => [it.x, it.y]).flattened.toList());
+    final linePositions = Float32List.fromList(points.map((it) => [(it.x / 2048) - 1, 1 - (it.y / 2048)]).flattened.toList());
     final linePositionsSlot = vertexShader.getUniformSlot('LinePositions');
 
     final linePositionsView = transientsBuffer.emplace(
-      linePositions.buffer.asByteData(0, 4096),
+      linePositions.buffer.asByteData(),
     );
 
     pass.bindUniform(linePositionsSlot, linePositionsView);
@@ -71,7 +71,7 @@ class LineGeometry extends UnskinnedGeometry {
 
   void bindLineStyle(HostBuffer transientsBuffer, RenderPass pass) {
     final lineStyleSlot = vertexShader.getUniformSlot('LineStyle');
-    final lineStyleView = transientsBuffer.emplace(Float32List.fromList([lineWidth]).buffer.asByteData());
+    final lineStyleView = transientsBuffer.emplace(Float32List.fromList([lineWidth / 2048]).buffer.asByteData());
     pass.bindUniform(lineStyleSlot, lineStyleView);
   }
 }

--- a/lib/src/gpu/line_geometry.dart
+++ b/lib/src/gpu/line_geometry.dart
@@ -1,0 +1,62 @@
+
+import 'dart:math';
+import 'dart:typed_data';
+
+import 'package:collection/collection.dart';
+import 'package:flutter_gpu/gpu.dart';
+import 'package:flutter_gpu/gpu.dart' as gpu;
+import 'package:flutter_scene/scene.dart';
+import 'package:vector_math/vector_math.dart';
+import 'package:vector_tile_renderer/src/gpu/shaders.dart';
+
+class LineGeometry extends UnskinnedGeometry {
+  final Iterable<Point<double>> points;
+
+  LineGeometry(this.points) {
+    setVertexShader(shaderLibrary["LineVertex"]!);
+
+    final pointCount = points.length;
+    if (pointCount > 1) {
+      List<double> vertices = List.empty(growable: true);
+      List<int> indices = List.empty(growable: true);
+
+      final segmentCount = pointCount - 1;
+
+      for (int i = 0; i < segmentCount; i++) {
+        double p0 = i + 0;
+        double p1 = i + 1;
+
+        vertices.addAll([p1, 1, p0]);
+        vertices.addAll([p0, 1, p1]);
+        vertices.addAll([p0, 0, p1]);
+        vertices.addAll([p1, 0, p0]);
+
+        indices.addAll([
+          0, 1, 2, 2, 3, 0
+        ].map((it) => it + (4 * i)));
+      }
+
+      uploadVertexData(
+        ByteData.sublistView(Float32List.fromList(vertices)),
+        8,
+        ByteData.sublistView(Uint16List.fromList(indices)),
+        indexType: gpu.IndexType.int16,
+      );
+    }
+  }
+
+
+  @override
+  void bind(RenderPass pass, HostBuffer transientsBuffer, Matrix4 modelTransform, Matrix4 cameraTransform, Vector3 cameraPosition) {
+    super.bind(pass, transientsBuffer, modelTransform, cameraTransform, cameraPosition);
+
+    final linePositions = Float32List.fromList(points.map((it) => [it.x, it.y]).flattened.toList());
+    final linePositionsSlot = vertexShader.getUniformSlot('LinePositions');
+
+    final linePositionsView = transientsBuffer.emplace(
+      linePositions.buffer.asByteData(),
+    );
+
+    pass.bindUniform(linePositionsSlot, linePositionsView);
+  }
+}

--- a/lib/src/gpu/line_geometry.dart
+++ b/lib/src/gpu/line_geometry.dart
@@ -55,6 +55,7 @@ class LineGeometry extends UnskinnedGeometry {
     super.bind(pass, transientsBuffer, modelTransform, cameraTransform, cameraPosition);
 
     bindPositions(transientsBuffer, pass);
+    bindLineStyle(transientsBuffer, pass);
   }
 
   void bindPositions(HostBuffer transientsBuffer, RenderPass pass) {
@@ -62,7 +63,7 @@ class LineGeometry extends UnskinnedGeometry {
     final linePositionsSlot = vertexShader.getUniformSlot('LinePositions');
 
     final linePositionsView = transientsBuffer.emplace(
-      linePositions.buffer.asByteData(),
+      linePositions.buffer.asByteData(0, 4096),
     );
 
     pass.bindUniform(linePositionsSlot, linePositionsView);

--- a/lib/src/gpu/line_material.dart
+++ b/lib/src/gpu/line_material.dart
@@ -1,9 +1,27 @@
 
+import 'dart:typed_data';
+
+import 'package:flutter_gpu/gpu.dart';
 import 'package:flutter_scene/scene.dart';
+import 'package:vector_math/vector_math.dart';
 import 'package:vector_tile_renderer/src/gpu/shaders.dart';
 
 class LineMaterial extends Material {
-  LineMaterial() {
+  Vector4 color;
+
+  LineMaterial(this.color) {
     setFragmentShader(shaderLibrary["SimpleFragment"]!);
+  }
+
+  @override
+  void bind(RenderPass pass, HostBuffer transientsBuffer, Environment environment) {
+    super.bind(pass, transientsBuffer, environment);
+
+    final colorBytes = Float32List.fromList([color.x, color.y, color.z, color.w]).buffer.asByteData();
+
+    pass.bindUniform(
+      fragmentShader.getUniformSlot("Paint"),
+      transientsBuffer.emplace(colorBytes),
+    );
   }
 }

--- a/lib/src/gpu/line_material.dart
+++ b/lib/src/gpu/line_material.dart
@@ -1,0 +1,9 @@
+
+import 'package:flutter_scene/scene.dart';
+import 'package:vector_tile_renderer/src/gpu/shaders.dart';
+
+class LineMaterial extends Material {
+  LineMaterial() {
+    setFragmentShader(shaderLibrary["SimpleFragment"]!);
+  }
+}

--- a/lib/src/gpu/scene_background_builder.dart
+++ b/lib/src/gpu/scene_background_builder.dart
@@ -1,0 +1,17 @@
+import 'package:flutter_scene/scene.dart';
+import 'package:vector_math/vector_math.dart';
+import 'package:vector_tile_renderer/src/gpu/background_geometry.dart';
+import 'package:vector_tile_renderer/src/gpu/colored_material.dart';
+
+import '../../vector_tile_renderer.dart';
+
+class SceneBackgroundBuilder {
+  final Scene scene;
+  final VisitorContext context;
+
+  SceneBackgroundBuilder(this.scene, this.context);
+
+  void addBackground(Vector4 color) {
+    scene.addMesh(Mesh(BackgroundGeometry(), ColoredMaterial(color)));
+  }
+}

--- a/lib/src/gpu/scene_building_visitor.dart
+++ b/lib/src/gpu/scene_building_visitor.dart
@@ -25,8 +25,7 @@ class SceneBuildingVisitor extends LayerVisitor {
       case ThemeLayerType.background:
       case ThemeLayerType.raster:
       case ThemeLayerType.unsupported:
-        context.logger.warn(
-            () => 'Unsupported layer type $layerType for features: $features');
+        return;
     }
   }
 

--- a/lib/src/gpu/scene_building_visitor.dart
+++ b/lib/src/gpu/scene_building_visitor.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/rendering.dart';
 import 'package:flutter_scene/scene.dart';
+import 'package:vector_tile_renderer/src/gpu/color_extension.dart';
+import 'package:vector_tile_renderer/src/gpu/scene_background_builder.dart';
 import 'package:vector_tile_renderer/src/gpu/scene_line_builder.dart';
-import 'package:vector_tile_renderer/src/model/tile_model.dart';
 import 'package:vector_tile_renderer/src/themes/feature_resolver.dart';
 import 'package:vector_tile_renderer/src/themes/style.dart';
 import 'package:vector_tile_renderer/src/themes/theme.dart';
@@ -30,7 +31,8 @@ class SceneBuildingVisitor extends LayerVisitor {
   }
 
   @override
-  void visitBackgound(VisitorContext context, Color color) {
-    //TODO
+  void visitBackground(VisitorContext context, Color color) {
+    SceneBackgroundBuilder(scene, context)
+        .addBackground(color.vector4);
   }
 }

--- a/lib/src/gpu/scene_line_builder.dart
+++ b/lib/src/gpu/scene_line_builder.dart
@@ -22,6 +22,8 @@ class SceneLineBuilder {
     const double lineWidth = 20;
     final linePoints = feature.feature.modelLines.expand((it) => {it.points}).flattened;
 
-    scene.addMesh(Mesh(LineGeometry(linePoints, lineWidth), UnlitMaterial()));
+    if (linePoints.isNotEmpty) {
+      scene.addMesh(Mesh(LineGeometry(linePoints, lineWidth), UnlitMaterial()));
+    }
   }
 }

--- a/lib/src/gpu/scene_line_builder.dart
+++ b/lib/src/gpu/scene_line_builder.dart
@@ -2,9 +2,11 @@ import 'package:collection/collection.dart';
 import 'package:flutter_scene/scene.dart';
 import 'package:vector_tile_renderer/src/gpu/line_geometry.dart';
 import 'package:vector_tile_renderer/src/gpu/line_material.dart';
+import 'package:vector_tile_renderer/src/themes/expression/expression.dart';
 import 'package:vector_tile_renderer/src/themes/feature_resolver.dart';
 import 'package:vector_tile_renderer/src/themes/style.dart';
-import 'package:vector_tile_renderer/src/themes/theme.dart';
+
+import '../../vector_tile_renderer.dart';
 
 class SceneLineBuilder {
   final Scene scene;
@@ -19,10 +21,15 @@ class SceneLineBuilder {
   }
 
   void addLine(Style style, LayerFeature feature) {
-    const double lineWidth = 20;
+
+    EvaluationContext evaluationContext = EvaluationContext(
+            () => {}, TileFeatureType.none, context.logger,
+        zoom: context.zoom, zoomScaleFactor: 1.0, hasImage: (_) => false);
+
+    final double lineWidth = style.linePaint?.evaluate(evaluationContext)?.strokeWidth ?? 0;
     final linePoints = feature.feature.modelLines.expand((it) => {it.points}).flattened;
 
-    if (linePoints.isNotEmpty) {
+    if (linePoints.isNotEmpty && lineWidth > 0) {
       scene.addMesh(Mesh(LineGeometry(linePoints, lineWidth), LineMaterial()));
     }
   }

--- a/lib/src/gpu/scene_line_builder.dart
+++ b/lib/src/gpu/scene_line_builder.dart
@@ -33,7 +33,14 @@ class SceneLineBuilder {
     final linePoints = feature.feature.modelLines.expand((it) => {it.points}).flattened;
 
     if (linePoints.isNotEmpty && lineWidth > 0) {
-      scene.addMesh(Mesh(LineGeometry(linePoints, lineWidth), LineMaterial(color)));
+
+      Geometry geometry = LineGeometry(
+          points: linePoints,
+          lineWidth: lineWidth,
+          extent: feature.layer.extent
+      );
+
+      scene.addMesh(Mesh(geometry, LineMaterial(color)));
     }
   }
 }

--- a/lib/src/gpu/scene_line_builder.dart
+++ b/lib/src/gpu/scene_line_builder.dart
@@ -23,7 +23,7 @@ class SceneLineBuilder {
     final linePoints = feature.feature.modelLines.expand((it) => {it.points}).flattened;
 
     if (linePoints.isNotEmpty) {
-      scene.addMesh(Mesh(LineGeometry(linePoints, lineWidth), UnlitMaterial()));
+      scene.addMesh(Mesh(LineGeometry(linePoints, lineWidth), LineMaterial()));
     }
   }
 }

--- a/lib/src/gpu/scene_line_builder.dart
+++ b/lib/src/gpu/scene_line_builder.dart
@@ -1,5 +1,7 @@
 import 'package:collection/collection.dart';
 import 'package:flutter_scene/scene.dart';
+import 'package:vector_math/vector_math.dart';
+import 'package:vector_tile_renderer/src/gpu/color_extension.dart';
 import 'package:vector_tile_renderer/src/gpu/line_geometry.dart';
 import 'package:vector_tile_renderer/src/gpu/line_material.dart';
 import 'package:vector_tile_renderer/src/themes/expression/expression.dart';
@@ -27,10 +29,11 @@ class SceneLineBuilder {
         zoom: context.zoom, zoomScaleFactor: 1.0, hasImage: (_) => false);
 
     final double lineWidth = style.linePaint?.evaluate(evaluationContext)?.strokeWidth ?? 0;
+    final Vector4 color = style.linePaint?.evaluate(evaluationContext)?.color.vector4 ?? Vector4(0, 0, 0, 0);
     final linePoints = feature.feature.modelLines.expand((it) => {it.points}).flattened;
 
     if (linePoints.isNotEmpty && lineWidth > 0) {
-      scene.addMesh(Mesh(LineGeometry(linePoints, lineWidth), LineMaterial()));
+      scene.addMesh(Mesh(LineGeometry(linePoints, lineWidth), LineMaterial(color)));
     }
   }
 }

--- a/lib/src/gpu/scene_line_builder.dart
+++ b/lib/src/gpu/scene_line_builder.dart
@@ -1,10 +1,7 @@
-import 'dart:typed_data';
-
 import 'package:collection/collection.dart';
-import 'package:flutter_gpu/gpu.dart' as gpu;
 import 'package:flutter_scene/scene.dart';
 import 'package:vector_tile_renderer/src/gpu/line_geometry.dart';
-import 'package:vector_tile_renderer/src/gpu/shaders.dart';
+import 'package:vector_tile_renderer/src/gpu/line_material.dart';
 import 'package:vector_tile_renderer/src/themes/feature_resolver.dart';
 import 'package:vector_tile_renderer/src/themes/style.dart';
 import 'package:vector_tile_renderer/src/themes/theme.dart';

--- a/lib/src/gpu/scene_line_builder.dart
+++ b/lib/src/gpu/scene_line_builder.dart
@@ -1,4 +1,6 @@
 import 'package:flutter_scene/scene.dart';
+import 'package:vector_math/vector_math.dart';
+import 'package:vector_tile_renderer/src/gpu/shaders.dart';
 import 'package:vector_tile_renderer/src/themes/feature_resolver.dart';
 import 'package:vector_tile_renderer/src/themes/style.dart';
 import 'package:vector_tile_renderer/src/themes/theme.dart';
@@ -16,6 +18,28 @@ class SceneLineBuilder {
   }
 
   void addLine(Style style, LayerFeature feature) {
-    // scene.addMesh()
+    UnskinnedGeometry geometry = UnskinnedGeometry();
+    geometry.setVertexShader(shaderLibrary["LineVertex"]!);
+    final pointCount = feature.feature.modelLines.expand((it) => {it.points}).length;
+
+    List<Vector3> vertices = List.empty(growable: true);
+
+    if (pointCount < 2) return;
+
+    final segmentCount = pointCount - 1;
+
+    for (int i = 0; i < segmentCount; i++) {
+      double p0 = i + 0;
+      double p1 = i + 1;
+      vertices.add(Vector3(p0, 1, p1));
+      vertices.add(Vector3(p0, 0, p1));
+      vertices.add(Vector3(p1, 1, p0));
+
+      vertices.add(Vector3(p1, 1, p0));
+      vertices.add(Vector3(p1, 0, p0));
+      vertices.add(Vector3(p0, 0, p1));
+    }
+
+    scene.addMesh(Mesh(geometry, UnlitMaterial()));
   }
 }

--- a/lib/src/gpu/scene_line_builder.dart
+++ b/lib/src/gpu/scene_line_builder.dart
@@ -1,7 +1,9 @@
 import 'dart:typed_data';
 
+import 'package:collection/collection.dart';
 import 'package:flutter_gpu/gpu.dart' as gpu;
 import 'package:flutter_scene/scene.dart';
+import 'package:vector_tile_renderer/src/gpu/line_geometry.dart';
 import 'package:vector_tile_renderer/src/gpu/shaders.dart';
 import 'package:vector_tile_renderer/src/themes/feature_resolver.dart';
 import 'package:vector_tile_renderer/src/themes/style.dart';
@@ -20,38 +22,8 @@ class SceneLineBuilder {
   }
 
   void addLine(Style style, LayerFeature feature) {
-    UnskinnedGeometry geometry = UnskinnedGeometry();
-    geometry.setVertexShader(shaderLibrary["LineVertex"]!);
-    final pointCount = feature.feature.modelLines.expand((it) => {it.points}).length;
+    final linePoints = feature.feature.modelLines.expand((it) => {it.points}).flattened;
 
-    List<double> vertices = List.empty(growable: true);
-    List<int> indices = List.empty(growable: true);
-
-    if (pointCount < 2) return;
-
-    final segmentCount = pointCount - 1;
-
-    for (int i = 0; i < segmentCount; i++) {
-      double p0 = i + 0;
-      double p1 = i + 1;
-
-      vertices.addAll([p1, 1, p0]);
-      vertices.addAll([p0, 1, p1]);
-      vertices.addAll([p0, 0, p1]);
-      vertices.addAll([p1, 0, p0]);
-
-      indices.addAll([
-        0, 1, 2, 2, 3, 0
-      ].map((it) => it + (4 * i)));
-    }
-
-    geometry.uploadVertexData(
-      ByteData.sublistView(Float32List.fromList(vertices)),
-      8,
-      ByteData.sublistView(Uint16List.fromList(indices)),
-      indexType: gpu.IndexType.int16,
-    );
-
-    scene.addMesh(Mesh(geometry, UnlitMaterial()));
+    scene.addMesh(Mesh(LineGeometry(linePoints), UnlitMaterial()));
   }
 }

--- a/lib/src/gpu/scene_line_builder.dart
+++ b/lib/src/gpu/scene_line_builder.dart
@@ -22,8 +22,9 @@ class SceneLineBuilder {
   }
 
   void addLine(Style style, LayerFeature feature) {
+    const double lineWidth = 20;
     final linePoints = feature.feature.modelLines.expand((it) => {it.points}).flattened;
 
-    scene.addMesh(Mesh(LineGeometry(linePoints), UnlitMaterial()));
+    scene.addMesh(Mesh(LineGeometry(linePoints, lineWidth), UnlitMaterial()));
   }
 }

--- a/lib/src/gpu/scene_line_builder.dart
+++ b/lib/src/gpu/scene_line_builder.dart
@@ -3,7 +3,7 @@ import 'package:flutter_scene/scene.dart';
 import 'package:vector_math/vector_math.dart';
 import 'package:vector_tile_renderer/src/gpu/color_extension.dart';
 import 'package:vector_tile_renderer/src/gpu/line_geometry.dart';
-import 'package:vector_tile_renderer/src/gpu/line_material.dart';
+import 'package:vector_tile_renderer/src/gpu/colored_material.dart';
 import 'package:vector_tile_renderer/src/themes/expression/expression.dart';
 import 'package:vector_tile_renderer/src/themes/feature_resolver.dart';
 import 'package:vector_tile_renderer/src/themes/style.dart';
@@ -40,7 +40,7 @@ class SceneLineBuilder {
           extent: feature.layer.extent
       );
 
-      scene.addMesh(Mesh(geometry, LineMaterial(color)));
+      scene.addMesh(Mesh(geometry, ColoredMaterial(color)));
     }
   }
 }

--- a/lib/src/gpu/tile_renderer.dart
+++ b/lib/src/gpu/tile_renderer.dart
@@ -68,6 +68,7 @@ class TileRenderer {
 
   Scene _createScene() {
     Scene scene = Scene();
+    scene.antiAliasingMode = AntiAliasingMode.msaa;
     final tileset = _tileset;
     if (tileset == null) {
       return scene;

--- a/lib/src/themes/theme.dart
+++ b/lib/src/themes/theme.dart
@@ -65,7 +65,7 @@ abstract class LayerVisitor {
   void visitFeatures(VisitorContext context, ThemeLayerType layerType,
       Style style, Iterable<LayerFeature> features);
 
-  void visitBackgound(VisitorContext context, Color color);
+  void visitBackground(VisitorContext context, Color color);
 }
 
 /// Represents a layer in the theme. Can [render] to a [Context], and specifies

--- a/lib/src/themes/theme_layers.dart
+++ b/lib/src/themes/theme_layers.dart
@@ -96,7 +96,7 @@ class BackgroundLayer extends ThemeLayer {
         () => {}, TileFeatureType.background, context.logger,
         zoom: context.zoom, zoomScaleFactor: 1.0, hasImage: (_) => false));
     if (color != null) {
-      visitor.visitBackgound(context, color);
+      visitor.visitBackground(context, color);
     }
   }
 

--- a/shaders/line.vert
+++ b/shaders/line.vert
@@ -5,7 +5,7 @@ uniform FrameInfo {
 }
 frame_info;
 
-#define MAX_POINTS 512
+#define MAX_POINTS 1024
 
 uniform LinePositions {
     vec2 points[MAX_POINTS];
@@ -17,7 +17,14 @@ uniform LineStyle {
 }
 line_style;
 
+
 in vec3 position;
+
+out vec3 v_position;
+out vec3 v_normal;
+out vec3 v_viewvector;
+out vec2 v_texture_coords;
+out vec4 v_color;
 
 void main() {
 
@@ -31,30 +38,10 @@ void main() {
   vec2 result = curr + (widthOffset * perp);
 
   gl_Position = vec4(result, 0.0, 1.0);
+
+  v_position = vec3(result, 0.0);
+  v_viewvector = frame_info.camera_position - v_position;
+  v_normal = vec3(1,0,0);
+  v_texture_coords = vec2(0, 0);
+  v_color = vec4(0,0,0,1);
 }
-
-
-
-// line that consists of segments
-// each segment is a line between two points
-//
-// uniform: p1 - p2 - p3
-// uniform: thickness
-//
-// need: normal from the line p1-p2, above or below
-//
-// index formula indates which point, and above or below
-// each point is represented by three numbers:
-// 1. index into the position uniform for the point
-// 2. above or below the line (-1 or 1)
-// 3. index into the normal uniform for the source/destination point
-//
-//
-// vertices:
-//
-//  a  ---- b
-//  p1 ---- p2
-//. c  ---- d
-//
-// c, a, b, c, d, b
-//

--- a/shaders/line.vert
+++ b/shaders/line.vert
@@ -8,7 +8,7 @@ frame_info;
 #define MAX_POINTS 1024
 
 uniform LinePositions {
-    vec2 points[MAX_POINTS];
+    vec4 points[MAX_POINTS];
 }
 line_positions;
 
@@ -28,8 +28,8 @@ out vec4 v_color;
 
 void main() {
 
-  vec2 curr = line_positions.points[int(position.x)];
-  vec2 next = line_positions.points[int(position.z)];
+  vec2 curr = line_positions.points[int(position.x)].xy;
+  vec2 next = line_positions.points[int(position.z)].xy;
   float widthOffset = position.y * line_style.width / 2.0;
 
   vec2 unitDir = normalize(next - curr);

--- a/shaders/line.vert
+++ b/shaders/line.vert
@@ -9,7 +9,7 @@ frame_info;
 
 uniform LinePositions {
     vec2 points[MAX_POINTS];
-}
+};
 
 // line that consists of segments
 // each segment is a line between two points

--- a/shaders/line.vert
+++ b/shaders/line.vert
@@ -9,11 +9,31 @@ frame_info;
 
 uniform LinePositions {
     vec2 points[MAX_POINTS];
-};
+}
+line_positions;
 
 uniform LineStyle {
   float width;
-};
+}
+line_style;
+
+in vec3 position;
+
+void main() {
+
+  vec2 curr = line_positions.points[int(position.x)];
+  vec2 next = line_positions.points[int(position.z)];
+  float widthOffset = position.y * line_style.width / 2.0;
+
+  vec2 unitDir = normalize(next - curr);
+  vec2 perp = vec2(unitDir.y, -unitDir.x);
+
+  vec2 result = curr + (widthOffset * perp);
+
+  gl_Position = vec4(result, 0.0, 1.0);
+}
+
+
 
 // line that consists of segments
 // each segment is a line between two points
@@ -22,31 +42,19 @@ uniform LineStyle {
 // uniform: thickness
 //
 // need: normal from the line p1-p2, above or below
-// 
-// index formula indates which point, and above or below
-// each point is represented by three numbers: 
-// 1. index into the position uniform for the point
-// 2. above or below the line (0 or 1)
-// 3. index into the normal uniform for the source/destination point
-// 
 //
-// vertices: 
+// index formula indates which point, and above or below
+// each point is represented by three numbers:
+// 1. index into the position uniform for the point
+// 2. above or below the line (-1 or 1)
+// 3. index into the normal uniform for the source/destination point
+//
+//
+// vertices:
 //
 //  a  ---- b
 //  p1 ---- p2
 //. c  ---- d
 //
 // c, a, b, c, d, b
-// 
-
-in vec3 position;
-
-out vec3 v_position;
-
-
-void main() {
-
-  vec4 model_position = frame_info.model_transform * vec4(position, 1.0);
-  v_position = model_position.xyz;
-  gl_Position = frame_info.camera_transform * model_position;
-}
+//

--- a/shaders/line.vert
+++ b/shaders/line.vert
@@ -11,6 +11,10 @@ uniform LinePositions {
     vec2 points[MAX_POINTS];
 };
 
+uniform LineStyle {
+  float width;
+};
+
 // line that consists of segments
 // each segment is a line between two points
 //
@@ -36,22 +40,13 @@ uniform LinePositions {
 // 
 
 in vec3 position;
-in vec3 normal;
-in vec2 texture_coords;
-in vec4 color;
 
 out vec3 v_position;
-out vec3 v_normal;
-out vec3 v_viewvector; // camera_position - vertex_position
-out vec2 v_texture_coords;
-out vec4 v_color;
+
 
 void main() {
+
   vec4 model_position = frame_info.model_transform * vec4(position, 1.0);
   v_position = model_position.xyz;
   gl_Position = frame_info.camera_transform * model_position;
-  v_viewvector = frame_info.camera_position - v_position;
-  v_normal = (mat3(frame_info.model_transform) * normal).xyz;
-  v_texture_coords = texture_coords;
-  v_color = color;
 }

--- a/shaders/simple.frag
+++ b/shaders/simple.frag
@@ -1,5 +1,11 @@
+
+uniform Paint {
+  vec4 color;
+}
+paint;
+
 out vec4 frag_color;
 
 void main() {
-  frag_color = vec4(0, 1, 0, 1);
+  frag_color = paint.color;
 }

--- a/shaders/simple.vert
+++ b/shaders/simple.vert
@@ -1,6 +1,25 @@
+uniform FrameInfo {
+  mat4 model_transform;
+  mat4 camera_transform;
+  vec3 camera_position;
+}
+frame_info;
 
-in vec2 position;
+in vec3 position;
+
+out vec3 v_position;
+out vec3 v_normal;
+out vec3 v_viewvector;
+out vec2 v_texture_coords;
+out vec4 v_color;
 
 void main() {
-  gl_Position = vec4(position, 0.0, 1.0);
+
+  gl_Position = vec4(position, 1.0);
+
+  v_position = position;
+  v_viewvector = frame_info.camera_position - v_position;
+  v_normal = vec3(1,0,0);
+  v_texture_coords = vec2(0, 0);
+  v_color = vec4(0,0,0,1);
 }


### PR DESCRIPTION
Changes:
- Draw lines, passing in the points and line width so that the GPU can calculate and draw triangles
- Draw background layer with two triangles
- Enable multi-sampled antialiasing


Todo:
-  Scale line width according to tile size
-  Safer handling of lines with many points (>1024)

<img width="755" alt="lines_bg" src="https://github.com/user-attachments/assets/3896e531-e730-40bb-ac34-cda7766752d3" />
