### PR TITLE
Relax vector_tile version constraint for 2.x/3.x compatibility

### DIFF
--- a/lib/src/themes/expression/comparison_expression.dart
+++ b/lib/src/themes/expression/comparison_expression.dart
@@ -55,7 +55,6 @@ class MatchExpression extends Expression {
   bool get isConstant => false;
 }
 
-@override
 Set<String> _createProperties(Expression input,
     final List<List<Expression>> values, final List<Expression> outputs) {
   final accumulator = {...input.properties()};

--- a/lib/src/themes/expression/interpolate_expression.dart
+++ b/lib/src/themes/expression/interpolate_expression.dart
@@ -67,7 +67,6 @@ abstract class InterpolateExpression extends Expression {
       InterpolationStop stopAbove);
 }
 
-@override
 Set<String> _createProperties(Expression input, List<InterpolationStop> stops) {
   final accumulator = {...input.properties()};
   for (final stop in stops) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  vector_tile: ^2.0.0
+  vector_tile: ">=2.0.0 <4.0.0"
   fixnum: ^1.0.0
   collection: ^1.17.2
   flutter_gpu:


### PR DESCRIPTION
## Summary
- Broaden the `vector_tile` dependency constraint from `^2.0.0` to `>=2.0.0 <4.0.0`.
- Keep compatibility with existing 2.x consumers while allowing 3.x in downstream apps.
- This helps resolve dependency constraints in apps that already use newer protobuf/vector_tile combinations.

## Validation
- Ran `flutter pub get` successfully.
- Ran `dart analyze` (only existing repo warning about missing `build/shaderbundles/` asset directory).


