### PR TITLE
Implement LayoutAnchor.bottom (6.0.0)

### DIFF
--- a/lib/src/features/extensions.dart
+++ b/lib/src/features/extensions.dart
@@ -15,6 +15,8 @@ extension LayoutAnchorExtension on LayoutAnchor {
         return Offset(-size.width / 2, -size.height / 2);
       case LayoutAnchor.top:
         return Offset(-size.width / 2, 0);
+      case LayoutAnchor.bottom:
+        return Offset(-size.width / 2, -size.height);
     }
     throw 'Not implemented: $name';
   }

--- a/lib/src/features/symbol_point_renderer.dart
+++ b/lib/src/features/symbol_point_renderer.dart
@@ -33,27 +33,20 @@ class SymbolPointRenderer extends FeatureRenderer {
     }
 
     final evaluationContext = EvaluationContext(
-      () => feature.properties,
-      feature.type,
-      logger,
-      zoom: context.zoom,
-      zoomScaleFactor: context.zoomScaleFactor,
-      hasImage: context.hasImage,
-    );
+        () => feature.properties, feature.type, logger,
+        zoom: context.zoom,
+        zoomScaleFactor: context.zoomScaleFactor,
+        hasImage: context.hasImage);
 
     final text = symbolLayout.text?.text.evaluate(evaluationContext);
-    final icon = symbolLayout.getIcon(
-      context,
-      evaluationContext,
-      layoutPlacement: LayoutPlacement.point,
-    );
+    final icon = symbolLayout.getIcon(context, evaluationContext,
+        layoutPlacement: LayoutPlacement.point);
     if (text == null && icon == null) {
       logger.warn(() => 'point with no text or icon');
       return;
     }
-    final textAbbreviation = text == null
-        ? null
-        : TextAbbreviator().abbreviate(text);
+    final textAbbreviation =
+        text == null ? null : TextAbbreviator().abbreviate(text);
     if (textAbbreviation != null &&
         !context.labelSpace.canAccept(textAbbreviation)) {
       return;
@@ -65,13 +58,11 @@ class SymbolPointRenderer extends FeatureRenderer {
     final textApproximation = lines == null
         ? null
         : TextApproximation(context, evaluationContext, style, lines);
-    final textAnchor =
-        symbolLayout.text?.anchor.evaluate(evaluationContext) ??
+    final textAnchor = symbolLayout.text?.anchor.evaluate(evaluationContext) ??
         LayoutAnchor.center;
     final rotationAlignment = symbolLayout.textRotationAlignment(
-      evaluationContext,
-      layoutPlacement: LayoutPlacement.line,
-    );
+        evaluationContext,
+        layoutPlacement: LayoutPlacement.line);
 
     logger.log(() => 'rendering symbol points');
 
@@ -98,21 +89,22 @@ class SymbolPointRenderer extends FeatureRenderer {
           context.canvas.translate(-offset.dx, -offset.dy);
         }
         if (icon != null) {
-          final occupied = icon.render(
-            offset,
-            contentSize: textApproximation?.renderer.size ?? Size.zero,
-            withRotation: false,
-          );
+          final occupied = icon.render(offset,
+              contentSize: textApproximation?.renderer.size ?? Size.zero,
+              withRotation: false);
           if (occupied != null) {
             if (!occupied.overlapsText && textAnchor == LayoutAnchor.top) {
               textOffset = textOffset.translate(0, occupied.area.height / 2.0);
+            } else if (!occupied.overlapsText &&
+                textAnchor == LayoutAnchor.bottom) {
+              textOffset = textOffset.translate(0, -occupied.area.height / 2.0);
             } else if (occupied.overlapsText &&
                 textAnchor == LayoutAnchor.center) {
               textOffset = textOffset.translate(
-                0,
-                (occupied.contentArea.top - occupied.area.top).abs() -
-                    (occupied.contentArea.bottom - occupied.area.bottom).abs(),
-              );
+                  0,
+                  (occupied.contentArea.top - occupied.area.top).abs() -
+                      (occupied.contentArea.bottom - occupied.area.bottom)
+                          .abs());
             }
           }
         }

--- a/lib/src/themes/style.dart
+++ b/lib/src/themes/style.dart
@@ -49,9 +49,10 @@ class LayoutAnchor {
   const LayoutAnchor._(this.name);
   static const center = LayoutAnchor._('center');
   static const top = LayoutAnchor._('top');
+  static const bottom = LayoutAnchor._('bottom');
   static const DEFAULT = center;
 
-  static List<LayoutAnchor> values() => [center, top];
+  static List<LayoutAnchor> values() => [center, top, bottom];
   static LayoutAnchor fromName(String? name) =>
       values().where((v) => v.name == name).firstOrNull() ?? DEFAULT;
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: vector_tile_renderer
 description: A vector tile renderer for use in creating map tile images or writing to a canvas.
-version: 7.0.0+beta.1
+version: 6.0.0
 homepage: https://github.com/greensopinion/dart-vector-tile-renderer
 
 environment:
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  vector_tile: ^3.0.0
+  vector_tile: ^2.0.0
   fixnum: ^1.0.0
   collection: ^1.19.1
 


### PR DESCRIPTION
This PR adds an implementation of ```LayoutAnchor.bottom```, mirroring the behaviour of ```LayoutAnchor.top```.

This allows placement of text labels above their icons.

<img width="277" height="276" alt="Screenshot 2026-03-29 at 11 33 29" src="https://github.com/user-attachments/assets/f05c22f2-1ca4-4da7-8d0a-e5f7d4fd6faa" />

I had to revise ```pubspec.yaml``` to match the 6.0.0 release.
Tested on the 6.0.0 branch.