### PR TITLE
update vector_tile dependency constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.0.1
+
+* update `vector_tile` dependency to include 4.x versions for compatibility with `protobuf` 6.x
+
 ## 6.0.0
 
 * add `raster-resampling` to raster layer

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  vector_tile: ^3.0.0
+  vector_tile: ">=3.0.0 <5.0.0"
   fixnum: ^1.0.0
   collection: ^1.19.1
 


### PR DESCRIPTION
3.x < 5.x to allow for protobuf 6.x
fixes issue #126