### PR TITLE
fix(gpu): use float uniform for text shader Age.milliseconds

### DIFF
--- a/lib/src/gpu/text/text_material.dart
+++ b/lib/src/gpu/text/text_material.dart
@@ -54,12 +54,13 @@ class TextMaterial extends UnlitMaterial {
 
     creationTimestamp ??= DateTime.now().millisecondsSinceEpoch;
 
+    // Impeller GLES only supports float uniforms; shader declares
+    // `Age { float milliseconds; }` so we pass a Float32 here.
     pass.bindUniform(
       fragmentShader.getUniformSlot("Age"),
-      transientsBuffer.emplace(Int64List.fromList(
-              [DateTime.now().millisecondsSinceEpoch - creationTimestamp!])
-          .buffer
-          .asByteData()),
+      transientsBuffer.emplace(Float32List.fromList([
+        (DateTime.now().millisecondsSinceEpoch - creationTimestamp!).toDouble(),
+      ]).buffer.asByteData()),
     );
 
     pass.bindTexture(fragmentShader.getUniformSlot('sdf'), baseColorTexture,

--- a/shaders/vector_tile_renderer$text.frag
+++ b/shaders/vector_tile_renderer$text.frag
@@ -4,8 +4,10 @@ uniform FragInfo {
 }
 frag_info;
 
+// NOTE: float (not int) for Impeller GLES compatibility — GLES backend only
+// supports float uniforms.
 uniform Age {
-  int milliseconds;
+  float milliseconds;
 }
 age;
 


### PR DESCRIPTION
Impeller's GLES backend only supports float uniforms. The text fragment shader declared Age.milliseconds as int, which crashed on devices falling back to GLES (e.g. Getac ZX10):

  Unsupported uniform data type for key: milliseconds, has type 7.
  Only float uniforms are supported.

Switch the uniform to float and bind a Float32List from text_material.