### PR TITLE
fix: vector tile dependacy for v6.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.1.1
+
+* fix `vector_tile` dependency to include 4.x versions
+
 ## 6.1.0
 
 * add support for `text-anchor` `bottom` and `icon-anchor` `bottom`

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: vector_tile_renderer
 description: A vector tile renderer for use in creating map tile images or writing to a canvas.
-version: 6.1.0
+version: 6.1.1
 
 environment:
   sdk: ^3.8.1
@@ -9,7 +9,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  vector_tile: ^2.0.0
+  vector_tile: ">=3.0.0 <5.0.0"
   fixnum: ^1.0.0
   collection: ^1.19.1
 


### PR DESCRIPTION
The vector tile dependency was updated to be >=3.0.0 <5.0.0 in the 6.1.0 version but has been overwritten back to ^2.0.0. The published dart package for 6.1.0 is still using 2.0.0 and is preventing updates to protobuf 6.0.0.